### PR TITLE
xfail attribute - invert the result of assertions

### DIFF
--- a/www/documentation/generated.html
+++ b/www/documentation/generated.html
@@ -109,7 +109,7 @@
 </section>
 
 <section id="the-scenario-element">
-<h2>The <code>scenario</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>scenario</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd><a href="#attr-scenario-xfail"><code>xfail</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 A scenario groups together the definition of the script environment
                 (the <a href="#the-call-element"><code>call</code></a> element) and the script assertions (the <a href="#the-context-element"><code>context</code></a> and
@@ -125,6 +125,11 @@
                reported. When present, only that assertion or scenario will be evaluated.
                Its content describes why you are focusing on this particular assertion or scenario.</p>
 <p id="attr-scenario-label">The <a href="#attr-scenario-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
+<p id="attr-scenario-xfail">Assertions with the <a href="#attr-scenario-xfail"><code>xfail</code></a> attribute will behave just like other assertions, but
+               will succeed where other assertions fail, and will fail where other assertions succeed (i.e. the result is inverted).
+               The <a href="#attr-scenario-xfail"><code>xfail</code></a> attribute can also be applied to scenarios, in which case <code>xfail</code> will be implicitly
+               set to <code>true</code> for all of the scenarios assertions.
+               The value of the <a href="#attr-scenario-xfail"><code>xfail</code></a> attribute must be <code>true</code>.</p>
 </section>
 
 <section id="the-call-element">
@@ -164,7 +169,7 @@
 </section>
 
 <section id="the-expect-element">
-<h2>The <code>expect</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>expect</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-xfail"><code>xfail</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 Defines what is expected from the context document(s).
             </p>
@@ -237,6 +242,11 @@
     &lt;x:was xml:space="preserve"&gt;Description of what the value actually was.&lt;/x:was&gt;
 &lt;/x:test-result&gt;
                                     </code></pre></li></ul>
+<p id="attr-expect-xfail">Assertions with the <a href="#attr-expect-xfail"><code>xfail</code></a> attribute will behave just like other assertions, but
+               will succeed where other assertions fail, and will fail where other assertions succeed (i.e. the result is inverted).
+               The <a href="#attr-expect-xfail"><code>xfail</code></a> attribute can also be applied to scenarios, in which case <code>xfail</code> will be implicitly
+               set to <code>true</code> for all of the scenarios assertions.
+               The value of the <a href="#attr-expect-xfail"><code>xfail</code></a> attribute must be <code>true</code>.</p>
 </section>
 
 

--- a/www/documentation/index.html
+++ b/www/documentation/index.html
@@ -187,7 +187,7 @@ table.simple {
   
     <h2 property="bibo:subtitle" id="subtitle">A tool for testing XProc scripts</h2>
   
-  <h2 property="dcterms:issued" datatype="xsd:dateTime" content="2014-05-09T08:37:41.000Z" id="unofficial-draft-09-may-2014">Unofficial Draft <time class="dt-published" datetime="2014-05-09">09 May 2014</time></h2>
+  <h2 property="dcterms:issued" datatype="xsd:dateTime" content="2014-05-09T10:35:34.000Z" id="unofficial-draft-09-may-2014">Unofficial Draft <time class="dt-published" datetime="2014-05-09">09 May 2014</time></h2>
   <dl>
     
     
@@ -263,7 +263,7 @@ table.simple {
 </section>
 
 <section id="the-scenario-element" typeof="bibo:Chapter" resource="#the-scenario-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-scenario-element"><span class="secno">1.3 </span>The <code>scenario</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-scenario-element"><span class="secno">1.3 </span>The <code>scenario</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd><a href="#attr-scenario-xfail"><code>xfail</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 A scenario groups together the definition of the script environment
                 (the <a href="#the-call-element"><code>call</code></a> element) and the script assertions (the <a href="#the-context-element"><code>context</code></a> and
@@ -279,6 +279,11 @@ table.simple {
                reported. When present, only that assertion or scenario will be evaluated.
                Its content describes why you are focusing on this particular assertion or scenario.</p>
 <p id="attr-scenario-label">The <a href="#attr-scenario-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
+<p id="attr-scenario-xfail">Assertions with the <a href="#attr-scenario-xfail"><code>xfail</code></a> attribute will behave just like other assertions, but
+               will succeed where other assertions fail, and will fail where other assertions succeed (i.e. the result is inverted).
+               The <a href="#attr-scenario-xfail"><code>xfail</code></a> attribute can also be applied to scenarios, in which case <code>xfail</code> will be implicitly
+               set to <code>true</code> for all of the scenarios assertions.
+               The value of the <a href="#attr-scenario-xfail"><code>xfail</code></a> attribute must be <code>true</code>.</p>
 </section>
 
 <section id="the-call-element" typeof="bibo:Chapter" resource="#the-call-element" rel="bibo:Chapter">
@@ -318,7 +323,7 @@ table.simple {
 </section>
 
 <section id="the-expect-element" typeof="bibo:Chapter" resource="#the-expect-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-expect-element"><span class="secno">1.7 </span>The <code>expect</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-expect-element"><span class="secno">1.7 </span>The <code>expect</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-xfail"><code>xfail</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 Defines what is expected from the context document(s).
             </p>
@@ -391,6 +396,11 @@ table.simple {
     &lt;x:was xml:space="preserve"&gt;Description of what the value actually was.&lt;/x:was&gt;
 &lt;/x:test-result&gt;
                                     </code></pre></li></ul>
+<p id="attr-expect-xfail">Assertions with the <a href="#attr-expect-xfail"><code>xfail</code></a> attribute will behave just like other assertions, but
+               will succeed where other assertions fail, and will fail where other assertions succeed (i.e. the result is inverted).
+               The <a href="#attr-expect-xfail"><code>xfail</code></a> attribute can also be applied to scenarios, in which case <code>xfail</code> will be implicitly
+               set to <code>true</code> for all of the scenarios assertions.
+               The value of the <a href="#attr-expect-xfail"><code>xfail</code></a> attribute must be <code>true</code>.</p>
 </section>
 
 

--- a/xprocspec/src/it/it-xprocspec/src/test/xprocspec/tests/expect-1.xprocspec
+++ b/xprocspec/src/it/it-xprocspec/src/test/xprocspec/tests/expect-1.xprocspec
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.daisy.org/ns/xprocspec/xprocspec.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <x:description xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:e="http://example.net/ns" script="../steps/identity.xpl">
-    
+
     <x:scenario label="identity - base-uri">
         <x:call step="e:identity">
             <x:option name="option.required" select="'option'"/>
         </x:call>
-        
+
         <x:context label="empty sequence"/>
         <x:expect type="xpath" label="test='false()' against a empty sequence should succeed" test="false()"/>
         <x:expect type="compare" label="compare two empty sequences"/>
         <x:expect type="count" label="the empty sequence contains at most 0 documents" max="0"/>
-        
+
         <x:context label="one document">
             <x:document type="inline">
                 <doc1 attr="value1"/>
@@ -25,7 +25,7 @@
         <x:expect type="count" label="a sequence of one document contains between 1 and 10 documents" min="1" max="10"/>
         <x:expect type="count" label="a sequence of one document contains between 0 and 1 document" min="0" max="1"/>
         <x:expect type="count" label="a sequence of one document contains between 1 and 1 document" min="1" max="1"/>
-        
+
         <x:context label="two documents">
             <x:document type="inline">
                 <doc1 attr="value1"/>
@@ -47,7 +47,7 @@
         <x:expect type="count" label="a sequence of two document contains between 1 and 2 documents" min="1" max="2"/>
         <x:expect type="count" label="a sequence of two document contains between 2 and 2 documents" min="2" max="2"/>
         <x:expect type="count" label="a sequence of two document contains at least 1 document" min="1"/>
-        
+
         <x:context label="single document with text node">
             <x:document type="inline">
                 <doc><![CDATA[   this string   contains several spaces   ]]></doc>
@@ -63,9 +63,9 @@
                 <doc><![CDATA[   this string   contains several spaces   ]]></doc>
             </x:document>
         </x:expect>
-        
+
         <!-- TODO: Validation is not tested. It is not implemented either. -->
-        
+
         <x:context label="a sequence of documents">
             <x:document type="inline">
                 <doc1/>
@@ -77,8 +77,37 @@
                 <doc3/>
             </x:document>
         </x:context>
-        <x:expect type="custom" label="The custom 'count' step should be successful." xmlns:custom="http://www.example.org/ns/custom" step="custom:count" href="../steps/custom-count.xpl" custom:count="[2,4]"/>
-        
+        <x:expect type="custom" label="The custom 'count' step should be successful." xmlns:custom="http://www.example.org/ns/custom" step="custom:count" href="../steps/custom-count.xpl"
+            custom:count="[2,4]"/>
+
+        <x:context label="a 'doc1'-document">
+            <x:document type="inline">
+                <doc1/>
+            </x:document>
+        </x:context>
+        <x:expect xfail="true" type="compare" label="...should not equal a 'doc2'-document (xfail attribute on `x:expect`-element)">
+            <x:document type="inline">
+                <doc2/>
+            </x:document>
+        </x:expect>
+
     </x:scenario>
-    
+
+    <x:scenario label="identity - xfail attribute on scenario" xfail="true">
+        <x:call step="e:identity">
+            <x:option name="option.required" select="'option'"/>
+        </x:call>
+
+        <x:context label="a 'doc1'-document">
+            <x:document type="inline">
+                <doc3/>
+            </x:document>
+        </x:context>
+        <x:expect type="compare" label="...should not equal a 'doc2'-document (xfail attribute on `x:expect`-element)">
+            <x:document type="inline">
+                <doc4/>
+            </x:document>
+        </x:expect>
+    </x:scenario>
+
 </x:description>

--- a/xprocspec/src/main/resources/content/xml/schema/xprocspec.rng
+++ b/xprocspec/src/main/resources/content/xml/schema/xprocspec.rng
@@ -114,6 +114,9 @@
     <define name="scenario.common">
         <ref name="common-attributes"/>
         <ref name="label"/>
+        <optional>
+            <ref name="xfail-attribute"/>
+        </optional>
     </define>
 
     <define name="scenario.common-children">
@@ -261,6 +264,9 @@
                 <ref name="pending-attribute"/>
                 <ref name="focus-attribute"/>
             </choice>
+        </optional>
+        <optional>
+            <ref name="xfail-attribute"/>
         </optional>
         <ref name="common-attributes"/>
     </define>
@@ -659,6 +665,19 @@
                Its content describes why you are focusing on this particular assertion or scenario.</p>
            </a:documentation>
             <data type="string"/>
+        </attribute>
+    </define>
+
+    <define name="xfail-attribute">
+        <attribute name="xfail">
+            <a:documentation xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve">
+               <p>Assertions with the <code>xfail</code> attribute will behave just like other assertions, but
+               will succeed where other assertions fail, and will fail where other assertions succeed (i.e. the result is inverted).
+               The <code>xfail</code> attribute can also be applied to scenarios, in which case <code>xfail</code> will be implicitly
+               set to <code>true</code> for all of the scenarios assertions.
+               The value of the <code>xfail</code> attribute must be <code>true</code>.</p>
+            </a:documentation>
+            <value>true</value>
         </attribute>
     </define>
 

--- a/xprocspec/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
+++ b/xprocspec/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
@@ -1,17 +1,17 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="pxi:test-evaluate" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/"
-    exclude-inline-prefixes="#all" version="1.0" xpath-version="2.0" xmlns:x="http://www.daisy.org/ns/xprocspec">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="pxi:test-evaluate" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step"
+    xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" exclude-inline-prefixes="#all" version="1.0" xpath-version="2.0" xmlns:x="http://www.daisy.org/ns/xprocspec">
 
     <p:input port="source" sequence="true"/>
     <p:output port="result" sequence="true"/>
     <p:option name="logfile" select="''"/>
-    
+
     <p:option name="step-available-rng" select="'false'"/>
 
     <p:import href="compare.xpl"/>
     <p:import href="../utils/logging-library.xpl"/>
     <p:import href="../utils/validate-with-relax-ng.xpl"/>
     <p:import href="../utils/document.xpl"/>
-    
+
     <!-- for custom x:expect implementations: -->
     <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
 
@@ -276,7 +276,8 @@
                                         </pxi:message>
                                         <p:wrap-sequence wrapper="x:test-result"/>
                                         <p:add-attribute match="/*" attribute-name="result">
-                                            <p:with-option name="attribute-value" select="if (($min='' or number($min) &lt;= number(.)) and ($max='' or number($max) &gt;= number(.))) then 'passed' else 'failed'"/>
+                                            <p:with-option name="attribute-value"
+                                                select="if (($min='' or number($min) &lt;= number(.)) and ($max='' or number($max) &gt;= number(.))) then 'passed' else 'failed'"/>
                                         </p:add-attribute>
                                         <pxi:message message="         * assertion $1">
                                             <p:with-option name="param1" select="/*/@result"/>
@@ -385,7 +386,7 @@
                                                 <p:document href="expect-to-custom-invocation.xsl"/>
                                             </p:input>
                                         </p:xslt>
-                                        
+
                                         <!-- multiplex context and expect document sequences for cx:eval -->
                                         <p:for-each name="custom.expect">
                                             <p:output port="result" sequence="true"/>
@@ -407,7 +408,7 @@
                                             </p:add-attribute>
                                             <p:add-attribute match="/*" attribute-name="port" attribute-value="context"/>
                                         </p:for-each>
-                                        
+
                                         <cx:eval>
                                             <p:input port="pipeline">
                                                 <p:pipe port="result" step="custom.expect-invocation"/>
@@ -440,7 +441,7 @@
                                         </pxi:message>
                                     </p:otherwise>
                                 </p:choose>
-                                
+
                                 <p:add-attribute match="/*" attribute-name="contextref" name="test-result.missing-attributes">
                                     <p:with-option name="attribute-value" select="/*/@contextref">
                                         <p:pipe port="result" step="assertion"/>
@@ -460,6 +461,21 @@
                                 </p:xslt>
                             </p:for-each>
                         </p:for-each>
+
+                        <!-- invert result on xfail -->
+                        <p:for-each>
+                            <p:choose>
+                                <p:when test="/*/@xfail='true'">
+                                    <p:add-attribute match="/*" attribute-name="result">
+                                        <p:with-option name="attribute-value" select="if (/*/@result='passed') then 'failed' else if (/*/@result='failed') then 'passed' else /*/@result"/>
+                                    </p:add-attribute>
+                                </p:when>
+                                <p:otherwise>
+                                    <p:identity/>
+                                </p:otherwise>
+                            </p:choose>
+                        </p:for-each>
+
                         <p:identity name="test-results"/>
 
                         <p:insert match="/*" position="last-child">

--- a/xprocspec/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
+++ b/xprocspec/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
@@ -727,6 +727,20 @@
                         </p:choose>
                         <p:delete match="//@focus"/>
 
+                        <p:choose>
+                            <p:when test="//x:scenario[@xfail='true']">
+                                <pxi:message message=" * inferring implicit xfail attributes...">
+                                    <p:with-option name="logfile" select="$logfile">
+                                        <p:empty/>
+                                    </p:with-option>
+                                </pxi:message>
+                                <p:add-attribute match="//x:expect[(ancestor::x:scenario/@xfail)[1]='true']" attribute-name="xfail" attribute-value="true"/>
+                            </p:when>
+                            <p:otherwise>
+                                <p:identity/>
+                            </p:otherwise>
+                        </p:choose>
+
                         <!-- create a new x:description document for each x:scenario element with inferred inputs, options and parameters -->
                         <pxi:message message=" * creating a new x:description document for each x:scenario element with inferred inputs, options and parameters">
                             <p:with-option name="logfile" select="$logfile">


### PR DESCRIPTION
Setting `xfail="true"` on either the `x:expect` or `x:scenario` element will invert the result of the assertion(s).

This allows you to assert for things that **should not be**, in addition to things that **should be**.

fixes #7

<!---
@huboard:{"order":16.0,"custom_state":""}
-->
