### PR TITLE
somewhat better errors, and a new x:documentation element

### DIFF
--- a/www/documentation/generated.html
+++ b/www/documentation/generated.html
@@ -84,7 +84,7 @@
 <section xmlns:x="http://www.daisy.org/ns/pipeline/xproc/test" xmlns:f="http://www.daisy.org/ns/pipeline/xproc/test/internal-functions" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">
 <h2>Definitions</h2>
 <section id="the-description-element">
-<h2>The <code>description</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-script-element"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#the-import-element"><code>import</code></a><small title="zero or more">*</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-description-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-script"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-version"><code>version</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>description</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd><a href="#the-script-element"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#the-import-element"><code>import</code></a><small title="zero or more">*</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-description-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-script"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-version"><code>version</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The <a href="#the-description-element"><code>description</code></a> element is the root element of an xprocspec test and describes the functionality of a specific XProc script.</p>
 
 <p id="attr-description-pending">Assertions or scenarios with the <a href="#attr-description-pending"><code>pending</code></a> attribute will remain untested, but will be
@@ -93,6 +93,16 @@
                Its content describes why the assertion or scenario should not be evaluated.</p>
 <p id="attr-description-script">The <a href="#attr-description-script"><code>script</code></a> attribute is a URI that points to the XProc script you want to test.</p>
 <p id="attr-description-version">The <a href="#attr-description-version"><code>version</code></a> attribute can be used to aid development over time.</p>
+</section>
+
+<section id="the-documentation-element">
+<h2>The <code>documentation</code> element</h2><dl class="element"><dt>Content model:</dt><dd>Zero or more elements from any namespace.</dd><dt>Content attributes:</dt><dd>None.</dd></dl>
+<p>
+                The documentation element contains human-readable documentation.
+                There are no constraints on the content of the p:documentation element.
+                Documentation is ignored when running xprocspec tests.
+            </p>
+
 </section>
 
 <section id="the-script-element">
@@ -107,8 +117,12 @@
 
 
 
+
+
+
+
 <section id="the-import-element">
-<h2>The <code>import</code> element</h2><dl class="element"><dt>Content model:</dt><dd>Empty.</dd><dt>Content attributes:</dt><dd><a href="#attr-import-href"><code>href</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>import</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dt>Content attributes:</dt><dd><a href="#attr-import-href"><code>href</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 An import runs the xprocspec description in the referenced file. It has no
                 effect on the scenarios in the current document, but can be a useful method
@@ -121,7 +135,7 @@
 </section>
 
 <section id="the-scenario-element">
-<h2>The <code>scenario</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>scenario</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 A scenario groups together the definition of the script environment
                 (the <a href="#the-call-element"><code>call</code></a> element) and the script assertions (the <a href="#the-context-element"><code>context</code></a> and
@@ -139,8 +153,10 @@
 <p id="attr-scenario-label">The <a href="#attr-scenario-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
 </section>
 
+
+
 <section id="the-call-element">
-<h2>The <code>call</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-input-element"><code>input</code></a><small title="zero or more">*</small></dd><dd><a href="#the-option-element"><code>option</code></a><small title="zero or more">*</small></dd><dd><a href="#the-param-element"><code>param</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-call-step"><code>step</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>call</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd><a href="#the-input-element"><code>input</code></a><small title="zero or more">*</small></dd><dd><a href="#the-option-element"><code>option</code></a><small title="zero or more">*</small></dd><dd><a href="#the-param-element"><code>param</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-call-step"><code>step</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 A <a href="#the-call-element"><code>call</code></a> element defines a step call and the
                 inputs, options and parameters passed to it.
@@ -156,7 +172,7 @@
 
 
 <section id="the-pending-element">
-<h2>The <code>pending</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-pending-label"><code>label</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>pending</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-pending-label"><code>label</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p><em>TODO</em>: the element <code>pending</code> has not been documented yet.</p>
 
 <p id="attr-pending-label">The <a href="#attr-pending-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
@@ -165,7 +181,7 @@
 
 
 <section id="the-context-element">
-<h2>The <code>context</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-context-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-context-pending"><code>pending</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>context</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-context-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-context-pending"><code>pending</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>Defines the context against which assertions are made.</p>
 
 <p id="attr-context-label">The <a href="#attr-context-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
@@ -176,7 +192,7 @@
 </section>
 
 <section id="the-expect-element">
-<h2>The <code>expect</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>expect</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 Defines what is expected from the context document(s).
             </p>
@@ -253,15 +269,17 @@
 
 
 
+
+
 <section id="the-input-element">
-<h2>The <code>input</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-input-port"><code>port</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>input</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-input-port"><code>port</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The input element is used to provide documents on the input ports of the XProc step you are testing.</p>
 
 <p id="attr-input-port"/>
 </section>
 
 <section id="the-option-element">
-<h2>The <code>option</code> element</h2><dl class="element"><dt>Content model:</dt><dd>Empty.</dd><dt>Content attributes:</dt><dd><a href="#attr-option-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-option-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>option</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-option-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-option-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The option element is used to provide values to XProc options on the XProc step you are testing.</p>
 
 <p id="attr-option-name">The <a href="#attr-option-name"><code>name</code></a> attribute is the name of the option used in the XProc step.</p>
@@ -274,7 +292,7 @@
 </section>
 
 <section id="the-param-element">
-<h2>The <code>param</code> element</h2><dl class="element"><dt>Content model:</dt><dd>Empty.</dd><dt>Content attributes:</dt><dd><a href="#attr-param-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-param-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>param</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-param-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-param-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The param element is used to provide values to XProc paramaters on the XProc step you are testing.</p>
 
 <p id="attr-param-name">The <a href="#attr-param-name"><code>name</code></a> attribute is the name of the parameter to be provided on the XProc steps primary parameter input
@@ -296,8 +314,12 @@
 
 
 
+
+
+
+
 <section id="the-document-element">
-<h2>The <code>document</code> element</h2><dl class="element"><dt>Content model:</dt><dd>One element from any namespace. (optional)</dd><dt>Content attributes:</dt><dd><a href="#attr-document-base-uri"><code>base-uri</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-method"><code>method</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-port"><code>port</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-position"><code>position</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-recursive"><code>recursive</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-select"><code>select</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>document</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd>One element from any namespace. (optional)</dd><dt>Content attributes:</dt><dd><a href="#attr-document-base-uri"><code>base-uri</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-method"><code>method</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-port"><code>port</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-position"><code>position</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-recursive"><code>recursive</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-select"><code>select</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The <a href="#the-document-element"><code>document</code></a> element is used to define which documents are provided on a steps input ports, what the context is when making assertions, and for assertions when making comparisons
                     or performing validations. It can be used in a number of ways:</p>
 

--- a/www/documentation/index.html
+++ b/www/documentation/index.html
@@ -187,7 +187,7 @@ table.simple {
   
     <h2 property="bibo:subtitle" id="subtitle">A tool for testing XProc scripts</h2>
   
-  <h2 property="dcterms:issued" datatype="xsd:dateTime" content="2014-05-09T13:05:54.000Z" id="unofficial-draft-09-may-2014">Unofficial Draft <time class="dt-published" datetime="2014-05-09">09 May 2014</time></h2>
+  <h2 property="dcterms:issued" datatype="xsd:dateTime" content="2014-05-12T12:30:22.000Z" id="unofficial-draft-12-may-2014">Unofficial Draft <time class="dt-published" datetime="2014-05-12">12 May 2014</time></h2>
   <dl>
     
     
@@ -233,12 +233,12 @@ table.simple {
     </p>
     
   
-</section><section id="toc"><h2 class="introductory" aria-level="1" role="heading" id="h2_toc">Table of Contents</h2><ul class="toc" role="directory" id="respecContents"><li class="tocline"><a href="#definitions" class="tocxref"><span class="secno">1. </span>Definitions</a><ul class="toc"><li class="tocline"><a href="#the-description-element" class="tocxref"><span class="secno">1.1 </span>The <code>description</code> element</a></li><li class="tocline"><a href="#the-script-element" class="tocxref"><span class="secno">1.2 </span>The <code>script</code> element</a></li><li class="tocline"><a href="#the-import-element" class="tocxref"><span class="secno">1.3 </span>The <code>import</code> element</a></li><li class="tocline"><a href="#the-scenario-element" class="tocxref"><span class="secno">1.4 </span>The <code>scenario</code> element</a></li><li class="tocline"><a href="#the-call-element" class="tocxref"><span class="secno">1.5 </span>The <code>call</code> element</a></li><li class="tocline"><a href="#the-pending-element" class="tocxref"><span class="secno">1.6 </span>The <code>pending</code> element</a></li><li class="tocline"><a href="#the-context-element" class="tocxref"><span class="secno">1.7 </span>The <code>context</code> element</a></li><li class="tocline"><a href="#the-expect-element" class="tocxref"><span class="secno">1.8 </span>The <code>expect</code> element</a></li><li class="tocline"><a href="#the-input-element" class="tocxref"><span class="secno">1.9 </span>The <code>input</code> element</a></li><li class="tocline"><a href="#the-option-element" class="tocxref"><span class="secno">1.10 </span>The <code>option</code> element</a></li><li class="tocline"><a href="#the-param-element" class="tocxref"><span class="secno">1.11 </span>The <code>param</code> element</a></li><li class="tocline"><a href="#the-document-element" class="tocxref"><span class="secno">1.12 </span>The <code>document</code> element</a></li></ul></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">A. </span>Acknowledgements</a></li></ul></section>
+</section><section id="toc"><h2 class="introductory" aria-level="1" role="heading" id="h2_toc">Table of Contents</h2><ul class="toc" role="directory" id="respecContents"><li class="tocline"><a href="#definitions" class="tocxref"><span class="secno">1. </span>Definitions</a><ul class="toc"><li class="tocline"><a href="#the-description-element" class="tocxref"><span class="secno">1.1 </span>The <code>description</code> element</a></li><li class="tocline"><a href="#the-documentation-element" class="tocxref"><span class="secno">1.2 </span>The <code>documentation</code> element</a></li><li class="tocline"><a href="#the-script-element" class="tocxref"><span class="secno">1.3 </span>The <code>script</code> element</a></li><li class="tocline"><a href="#the-import-element" class="tocxref"><span class="secno">1.4 </span>The <code>import</code> element</a></li><li class="tocline"><a href="#the-scenario-element" class="tocxref"><span class="secno">1.5 </span>The <code>scenario</code> element</a></li><li class="tocline"><a href="#the-call-element" class="tocxref"><span class="secno">1.6 </span>The <code>call</code> element</a></li><li class="tocline"><a href="#the-pending-element" class="tocxref"><span class="secno">1.7 </span>The <code>pending</code> element</a></li><li class="tocline"><a href="#the-context-element" class="tocxref"><span class="secno">1.8 </span>The <code>context</code> element</a></li><li class="tocline"><a href="#the-expect-element" class="tocxref"><span class="secno">1.9 </span>The <code>expect</code> element</a></li><li class="tocline"><a href="#the-input-element" class="tocxref"><span class="secno">1.10 </span>The <code>input</code> element</a></li><li class="tocline"><a href="#the-option-element" class="tocxref"><span class="secno">1.11 </span>The <code>option</code> element</a></li><li class="tocline"><a href="#the-param-element" class="tocxref"><span class="secno">1.12 </span>The <code>param</code> element</a></li><li class="tocline"><a href="#the-document-element" class="tocxref"><span class="secno">1.13 </span>The <code>document</code> element</a></li></ul></li><li class="tocline"><a href="#acknowledgements" class="tocxref"><span class="secno">A. </span>Acknowledgements</a></li></ul></section>
         
 <section xmlns:x="http://www.daisy.org/ns/pipeline/xproc/test" xmlns:f="http://www.daisy.org/ns/pipeline/xproc/test/internal-functions" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" id="definitions">
 <!--OddPage--><h2 aria-level="1" role="heading" id="h2_definitions"><span class="secno">1. </span>Definitions</h2>
 <section id="the-description-element" typeof="bibo:Chapter" resource="#the-description-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-description-element"><span class="secno">1.1 </span>The <code>description</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-script-element"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#the-import-element"><code>import</code></a><small title="zero or more">*</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-description-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-script"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-version"><code>version</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-description-element"><span class="secno">1.1 </span>The <code>description</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd><a href="#the-script-element"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#the-import-element"><code>import</code></a><small title="zero or more">*</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-description-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-script"><code>script</code></a><small title="optional">?</small></dd><dd><a href="#attr-description-version"><code>version</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The <a href="#the-description-element"><code>description</code></a> element is the root element of an xprocspec test and describes the functionality of a specific XProc script.</p>
 
 <p id="attr-description-pending">Assertions or scenarios with the <a href="#attr-description-pending"><code>pending</code></a> attribute will remain untested, but will be
@@ -249,8 +249,18 @@ table.simple {
 <p id="attr-description-version">The <a href="#attr-description-version"><code>version</code></a> attribute can be used to aid development over time.</p>
 </section>
 
+<section id="the-documentation-element" typeof="bibo:Chapter" resource="#the-documentation-element" rel="bibo:Chapter">
+<h3 aria-level="2" role="heading" id="h3_the-documentation-element"><span class="secno">1.2 </span>The <code>documentation</code> element</h3><dl class="element"><dt>Content model:</dt><dd>Zero or more elements from any namespace.</dd><dt>Content attributes:</dt><dd>None.</dd></dl>
+<p>
+                The documentation element contains human-readable documentation.
+                There are no constraints on the content of the p:documentation element.
+                Documentation is ignored when running xprocspec tests.
+            </p>
+
+</section>
+
 <section id="the-script-element" typeof="bibo:Chapter" resource="#the-script-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-script-element"><span class="secno">1.2 </span>The <code>script</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-declare-step-element"><code>declare-step</code></a><small title="optional">?</small></dd><dd><a href="#the-pipeline-element"><code>pipeline</code></a><small title="optional">?</small></dd><dd><a href="#the-library-element"><code>library</code></a><small title="optional">?</small></dd><dt>Content attributes:</dt><dd>None.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-script-element"><span class="secno">1.3 </span>The <code>script</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-declare-step-element"><code>declare-step</code></a><small title="optional">?</small></dd><dd><a href="#the-pipeline-element"><code>pipeline</code></a><small title="optional">?</small></dd><dd><a href="#the-library-element"><code>library</code></a><small title="optional">?</small></dd><dt>Content attributes:</dt><dd>None.</dd></dl>
 <p>The script element can be used insted of the <a href="#attr-script-script"><code>script</code></a> attribute.
                 It allows you to inline the XProc script to test.
                 The base URI of the script is the same as the containing xprocspec document,
@@ -261,8 +271,12 @@ table.simple {
 
 
 
+
+
+
+
 <section id="the-import-element" typeof="bibo:Chapter" resource="#the-import-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-import-element"><span class="secno">1.3 </span>The <code>import</code> element</h3><dl class="element"><dt>Content model:</dt><dd>Empty.</dd><dt>Content attributes:</dt><dd><a href="#attr-import-href"><code>href</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-import-element"><span class="secno">1.4 </span>The <code>import</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dt>Content attributes:</dt><dd><a href="#attr-import-href"><code>href</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 An import runs the xprocspec description in the referenced file. It has no
                 effect on the scenarios in the current document, but can be a useful method
@@ -275,7 +289,7 @@ table.simple {
 </section>
 
 <section id="the-scenario-element" typeof="bibo:Chapter" resource="#the-scenario-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-scenario-element"><span class="secno">1.4 </span>The <code>scenario</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-scenario-element"><span class="secno">1.5 </span>The <code>scenario</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd><a href="#the-call-element"><code>call</code></a><small title="optional">?</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dd><a href="#the-context-element"><code>context</code></a><small title="zero or more">*</small></dd><dd><a href="#the-expect-element"><code>expect</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-scenario-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-scenario-label"><code>label</code></a></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 A scenario groups together the definition of the script environment
                 (the <a href="#the-call-element"><code>call</code></a> element) and the script assertions (the <a href="#the-context-element"><code>context</code></a> and
@@ -293,8 +307,10 @@ table.simple {
 <p id="attr-scenario-label">The <a href="#attr-scenario-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
 </section>
 
+
+
 <section id="the-call-element" typeof="bibo:Chapter" resource="#the-call-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-call-element"><span class="secno">1.5 </span>The <code>call</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-input-element"><code>input</code></a><small title="zero or more">*</small></dd><dd><a href="#the-option-element"><code>option</code></a><small title="zero or more">*</small></dd><dd><a href="#the-param-element"><code>param</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-call-step"><code>step</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-call-element"><span class="secno">1.6 </span>The <code>call</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd><a href="#the-input-element"><code>input</code></a><small title="zero or more">*</small></dd><dd><a href="#the-option-element"><code>option</code></a><small title="zero or more">*</small></dd><dd><a href="#the-param-element"><code>param</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-call-step"><code>step</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 A <a href="#the-call-element"><code>call</code></a> element defines a step call and the
                 inputs, options and parameters passed to it.
@@ -310,7 +326,7 @@ table.simple {
 
 
 <section id="the-pending-element" typeof="bibo:Chapter" resource="#the-pending-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-pending-element"><span class="secno">1.6 </span>The <code>pending</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-pending-label"><code>label</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-pending-element"><span class="secno">1.7 </span>The <code>pending</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dd><a href="#the-scenario-element"><code>scenario</code></a><small title="zero or more">*</small></dd><dd><a href="#the-pending-element"><code>pending</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-pending-label"><code>label</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p><em>TODO</em>: the element <code>pending</code> has not been documented yet.</p>
 
 <p id="attr-pending-label">The <a href="#attr-pending-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
@@ -319,7 +335,7 @@ table.simple {
 
 
 <section id="the-context-element" typeof="bibo:Chapter" resource="#the-context-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-context-element"><span class="secno">1.7 </span>The <code>context</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-context-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-context-pending"><code>pending</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-context-element"><span class="secno">1.8 </span>The <code>context</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-context-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-context-pending"><code>pending</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>Defines the context against which assertions are made.</p>
 
 <p id="attr-context-label">The <a href="#attr-context-label"><code>label</code></a> attribute is used to describe the current element in human-readable words.</p>
@@ -330,7 +346,7 @@ table.simple {
 </section>
 
 <section id="the-expect-element" typeof="bibo:Chapter" resource="#the-expect-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-expect-element"><span class="secno">1.8 </span>The <code>expect</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-expect-element"><span class="secno">1.9 </span>The <code>expect</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-expect-equals"><code>equals</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-focus"><code>focus</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-grammar"><code>grammar</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-label"><code>label</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-max"><code>max</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-min"><code>min</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-normalize-space"><code>normalize-space</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-pending"><code>pending</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-step"><code>step</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-test"><code>test</code></a><small title="optional">?</small></dd><dd><a href="#attr-expect-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>
                 Defines what is expected from the context document(s).
             </p>
@@ -407,15 +423,17 @@ table.simple {
 
 
 
+
+
 <section id="the-input-element" typeof="bibo:Chapter" resource="#the-input-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-input-element"><span class="secno">1.9 </span>The <code>input</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-input-port"><code>port</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-input-element"><span class="secno">1.10 </span>The <code>input</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dd><a href="#the-document-element"><code>document</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-input-port"><code>port</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The input element is used to provide documents on the input ports of the XProc step you are testing.</p>
 
 <p id="attr-input-port">
 </p></section>
 
 <section id="the-option-element" typeof="bibo:Chapter" resource="#the-option-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-option-element"><span class="secno">1.10 </span>The <code>option</code> element</h3><dl class="element"><dt>Content model:</dt><dd>Empty.</dd><dt>Content attributes:</dt><dd><a href="#attr-option-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-option-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-option-element"><span class="secno">1.11 </span>The <code>option</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-option-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-option-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The option element is used to provide values to XProc options on the XProc step you are testing.</p>
 
 <p id="attr-option-name">The <a href="#attr-option-name"><code>name</code></a> attribute is the name of the option used in the XProc step.</p>
@@ -428,7 +446,7 @@ table.simple {
 </section>
 
 <section id="the-param-element" typeof="bibo:Chapter" resource="#the-param-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-param-element"><span class="secno">1.11 </span>The <code>param</code> element</h3><dl class="element"><dt>Content model:</dt><dd>Empty.</dd><dt>Content attributes:</dt><dd><a href="#attr-param-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-param-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-param-element"><span class="secno">1.12 </span>The <code>param</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="zero or more">*</small></dd><dt>Content attributes:</dt><dd><a href="#attr-param-name"><code>name</code></a><small title="optional">?</small></dd><dd><a href="#attr-param-select"><code>select</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The param element is used to provide values to XProc paramaters on the XProc step you are testing.</p>
 
 <p id="attr-param-name">The <a href="#attr-param-name"><code>name</code></a> attribute is the name of the parameter to be provided on the XProc steps primary parameter input
@@ -450,8 +468,12 @@ table.simple {
 
 
 
+
+
+
+
 <section id="the-document-element" typeof="bibo:Chapter" resource="#the-document-element" rel="bibo:Chapter">
-<h3 aria-level="2" role="heading" id="h3_the-document-element"><span class="secno">1.12 </span>The <code>document</code> element</h3><dl class="element"><dt>Content model:</dt><dd>One element from any namespace. (optional)</dd><dt>Content attributes:</dt><dd><a href="#attr-document-base-uri"><code>base-uri</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-method"><code>method</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-port"><code>port</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-position"><code>position</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-recursive"><code>recursive</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-select"><code>select</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h3 aria-level="2" role="heading" id="h3_the-document-element"><span class="secno">1.13 </span>The <code>document</code> element</h3><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd>One element from any namespace. (optional)</dd><dt>Content attributes:</dt><dd><a href="#attr-document-base-uri"><code>base-uri</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-method"><code>method</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-port"><code>port</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-position"><code>position</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-recursive"><code>recursive</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-select"><code>select</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The <a href="#the-document-element"><code>document</code></a> element is used to define which documents are provided on a steps input ports, what the context is when making assertions, and for assertions when making comparisons
                     or performing validations. It can be used in a number of ways:</p>
 

--- a/xprocspec/src/it/it-xprocspec/src/test/xprocspec/tests/description-1.xprocspec
+++ b/xprocspec/src/it/it-xprocspec/src/test/xprocspec/tests/description-1.xprocspec
@@ -2,15 +2,22 @@
 <?xml-model href="http://www.daisy.org/ns/xprocspec/xprocspec.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <x:description xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:e="http://example.net/ns" script="../steps/identity.xpl">
 
+    <x:documentation>x:description-documentation</x:documentation>
+
     <x:scenario label="identity">
+        <x:documentation>x:scenario-documentation</x:documentation>
         <x:call step="e:identity">
+            <x:documentation>x:call-documentation</x:documentation>
             <x:option name="option" select="'option-value'"/>
             <x:option name="option.required" select="'option.required-value'"/>
         </x:call>
         <x:context label="the results">
+            <x:documentation>x:context-documentation</x:documentation>
             <x:document type="port" port="options"/>
         </x:context>
-        <x:expect type="xpath" label="the option 'option' should have the value 'option-value'" test="/*/*[@name='option']/@value='option-value'"/>
+        <x:expect type="xpath" label="the option 'option' should have the value 'option-value'" test="/*/*[@name='option']/@value='option-value'">
+            <x:documentation>x:expect-documentation</x:documentation>
+        </x:expect>
         <x:expect type="xpath" label="the option 'option.required' should have the value 'option-value'" test="/*/*[@name='option.required']/@value='option.required-value'"/>
     </x:scenario>
 

--- a/xprocspec/src/it/it-xprocspec/src/test/xprocspec/tests/documentation-1.xprocspec
+++ b/xprocspec/src/it/it-xprocspec/src/test/xprocspec/tests/documentation-1.xprocspec
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.daisy.org/ns/xprocspec/xprocspec.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<x:description xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:e="http://example.net/ns" script="../../../../../../../src/main/resources/content/xml/xproc/xprocspec.xpl">
+
+    <x:scenario label="identity">
+        <x:call step="x:xprocspec">
+            <x:input port="source">
+                <x:document href="description-1.xprocspec" type="file"/>
+            </x:input>
+            <x:option name="temp-dir" select="$temp-dir"/>
+        </x:call>
+        <x:context label="the results">
+            <x:document type="port" port="result"/>
+        </x:context>
+        <x:expect type="count" label="there should be exactly 1 document on the result port" min="1" max="1"/>
+        <x:expect type="xpath" label="There should be exactly 5 x:documentation elements in the results" test="count(/*/x:description[1]//x:documentation)" equals="5"/>
+        <x:expect type="xpath" label="There should be a x:documentation element with the content 'x:description-documentation' in the results"
+            test="//x:documentation[.='x:description-documentation']/text()" equals="'x:description-documentation'"/>
+        <x:expect type="xpath" label="There should be a x:documentation element with the content 'x:scenario-documentation' in the results"
+            test="//x:documentation[.='x:scenario-documentation']/text()" equals="'x:scenario-documentation'"/>
+        <x:expect type="xpath" label="There should be a x:documentation element with the content 'x:call-documentation' in the results" test="//x:documentation[.='x:call-documentation']/text()"
+            equals="'x:call-documentation'"/>
+        <x:expect type="xpath" label="There should be a x:documentation element with the content 'x:context-documentation' in the results" test="//x:documentation[.='x:context-documentation']/text()"
+            equals="'x:context-documentation'"/>
+        <x:expect type="xpath" label="There should be a x:documentation element with the content 'x:expect-documentation' in the results" test="//x:documentation[.='x:expect-documentation']/text()"
+            equals="'x:expect-documentation'"/>
+    </x:scenario>
+
+</x:description>

--- a/xprocspec/src/main/resources/content/xml/schema/xprocspec.evaluate.rng
+++ b/xprocspec/src/main/resources/content/xml/schema/xprocspec.evaluate.rng
@@ -49,6 +49,7 @@
                     The expected content and the actual content are contained in the x:expected and x:was elements respectively.
                 </a:documentation>
                 <ref name="common-attributes"/>
+                <ref name="common-elements"/>
                 <ref name="label"/>
                 <optional>
                     <ref name="pending-attribute"/>

--- a/xprocspec/src/main/resources/content/xml/schema/xprocspec.preprocess.rng
+++ b/xprocspec/src/main/resources/content/xml/schema/xprocspec.preprocess.rng
@@ -32,6 +32,7 @@
 
         <define name="description.common">
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <attribute name="script">
                 <a:documentation xmlns="http://www.w3.org/1999/xhtml">The `script` attribute is a URI that points to the XProc script you want to test.</a:documentation>
                 <data type="anyURI"/>
@@ -63,6 +64,7 @@
 
         <define name="context.attributes">
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <optional>
                 <ref name="pending-attribute"/>
             </optional>
@@ -74,6 +76,7 @@
 
         <define name="expect.attributes">
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <optional>
                 <ref name="pending-attribute"/>
             </optional>
@@ -113,6 +116,7 @@
                     <attribute name="xml:base"/>
                 </choice>
             </zeroOrMore>
+            <ref name="common-elements"/>
             <attribute name="error-location"/>
             <attribute name="test-base-uri"/>
             <optional>
@@ -121,6 +125,7 @@
             <zeroOrMore>
                 <element name="error" ns="http://www.w3.org/ns/xproc-step">
                     <ref name="common-attributes"/>
+                    <ref name="common-elements"/>
                     <optional>
                         <attribute name="name">
                             <data type="NCName"/>
@@ -214,6 +219,7 @@
             </attribute>
         </optional>
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
     </define>
 
     <define name="xproc.declare-step">
@@ -353,6 +359,7 @@
         </attribute>
         <ref name="xproc.common"/>
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
     </define>
 
     <define name="xproc.document-inline-data">

--- a/xprocspec/src/main/resources/content/xml/schema/xprocspec.rng
+++ b/xprocspec/src/main/resources/content/xml/schema/xprocspec.rng
@@ -38,6 +38,7 @@
 
     <define name="description.common">
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
         <choice>
             <ref name="script"/>
             <attribute name="script">
@@ -101,6 +102,23 @@
         </zeroOrMore>
     </define>
 
+    <define name="common-elements">
+        <optional>
+            <ref name="documentation"/>
+        </optional>
+    </define>
+
+    <define name="documentation">
+        <element name="documentation" ns="http://www.daisy.org/ns/xprocspec">
+            <a:documentation xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve">
+                The documentation element contains human-readable documentation.
+                There are no constraints on the content of the p:documentation element.
+                Documentation is ignored when running xprocspec tests.
+            </a:documentation>
+            <ref name="any-content"/>
+        </element>
+    </define>
+
     <define name="import">
         <element name="import" ns="http://www.daisy.org/ns/xprocspec">
             <a:documentation xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve">
@@ -111,6 +129,7 @@
                 imported document will actually be imported).
             </a:documentation>
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <attribute name="href">
                 <a:documentation xmlns="http://www.w3.org/1999/xhtml">The `href` attribute contains a URI pointing to the xprocspec file to be imported.</a:documentation>
                 <data type="anyURI"/>
@@ -145,6 +164,7 @@
 
     <define name="scenario.common">
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
         <ref name="label"/>
     </define>
 
@@ -173,6 +193,7 @@
 
     <define name="call.common">
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
         <zeroOrMore>
             <choice>
                 <ref name="input"/>
@@ -206,6 +227,7 @@
         <element name="option" ns="http://www.daisy.org/ns/xprocspec">
             <a:documentation xmlns="http://www.w3.org/1999/xhtml">The option element is used to provide values to XProc options on the XProc step you are testing.</a:documentation>
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <attribute name="name">
                 <a:documentation xmlns="http://www.w3.org/1999/xhtml">The `name` attribute is the name of the option used in the XProc step.</a:documentation>
                 <data type="QName"/>
@@ -228,6 +250,7 @@
         <element name="param" ns="http://www.daisy.org/ns/xprocspec">
             <a:documentation xmlns="http://www.w3.org/1999/xhtml">The param element is used to provide values to XProc paramaters on the XProc step you are testing.</a:documentation>
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <attribute name="name">
                 <a:documentation xmlns="http://www.w3.org/1999/xhtml">The `name` attribute is the name of the parameter to be provided on the XProc steps primary parameter input
                     port.</a:documentation>
@@ -248,6 +271,7 @@
         <element name="input" ns="http://www.daisy.org/ns/xprocspec">
             <a:documentation xmlns="http://www.w3.org/1999/xhtml">The input element is used to provide documents on the input ports of the XProc step you are testing.</a:documentation>
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <attribute name="port">
                 <data type="string">
                     <param name="pattern">.+</param>
@@ -270,6 +294,7 @@
 
     <define name="context.attributes">
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
         <optional>
             <ref name="pending-attribute"/>
         </optional>
@@ -295,6 +320,7 @@
             </choice>
         </optional>
         <ref name="common-attributes"/>
+        <ref name="common-elements"/>
     </define>
 
     <define name="expect">
@@ -469,6 +495,7 @@
                     or performing validations. It can be used in a number of ways:</p>
             </a:documentation>
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <optional>
                 <attribute name="select">
                     <a:documentation xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve">
@@ -618,6 +645,7 @@
                 the pending assertions and scenarios in the resulting reports.</p>
             </a:documentation>
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <optional>
                 <ref name="label"/>
             </optional>
@@ -644,6 +672,7 @@
     <define name="pending-scenario-wrapped">
         <element name="pending" ns="http://www.daisy.org/ns/xprocspec">
             <ref name="common-attributes"/>
+            <ref name="common-elements"/>
             <optional>
                 <ref name="label"/>
             </optional>

--- a/xprocspec/src/main/resources/content/xml/schema/xprocspec.run.rng
+++ b/xprocspec/src/main/resources/content/xml/schema/xprocspec.run.rng
@@ -34,7 +34,7 @@
                 </choice>
             </element>
         </define>
-        
+
         <define name="scenario">
             <element name="scenario" ns="http://www.daisy.org/ns/xprocspec">
                 <a:documentation>after execution, the scenario will contain the start-time and end-time attributes</a:documentation>
@@ -48,7 +48,7 @@
                 </attribute>
             </element>
         </define>
-        
+
         <define name="pending-scenario-attribute">
             <element name="scenario" ns="http://www.daisy.org/ns/xprocspec">
                 <ref name="pending-attribute"/>
@@ -74,7 +74,8 @@
 
         <define name="xproc.param-set">
             <element name="inline" ns="http://www.w3.org/ns/xproc">
-                <a:documentation>after execution, the set of parameters are inferred and provided as a c:param-set inside a p:inline on the parameter input port in the step-declaration</a:documentation>
+                <a:documentation>after execution, the set of parameters are inferred and provided as a c:param-set inside a p:inline on the parameter input port in the
+                    step-declaration</a:documentation>
                 <ref name="any-attribute"/>
                 <element name="param-set" ns="http://www.w3.org/ns/xproc-step">
                     <zeroOrMore>
@@ -100,6 +101,7 @@
             <element name="option" ns="http://www.daisy.org/ns/xprocspec">
                 <attribute name="value"/>
                 <ref name="common-attributes"/>
+                <ref name="common-elements"/>
                 <attribute name="name">
                     <data type="QName"/>
                 </attribute>
@@ -118,6 +120,7 @@
             <element name="param" ns="http://www.daisy.org/ns/xprocspec">
                 <attribute name="value"/>
                 <ref name="common-attributes"/>
+                <ref name="common-elements"/>
                 <attribute name="name">
                     <data type="QName"/>
                 </attribute>

--- a/xprocspec/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
+++ b/xprocspec/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
@@ -14,7 +14,7 @@
     
     <!-- for custom x:expect implementations: -->
     <p:import href="http://xmlcalabash.com/extension/steps/library-1.0.xpl"/>
-
+    
     <p:for-each name="current-test">
         <!-- for each scenario -->
 

--- a/xprocspec/src/main/resources/content/xml/xproc/preprocess/infer-scenarios.xsl
+++ b/xprocspec/src/main/resources/content/xml/xproc/preprocess/infer-scenarios.xsl
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:c="http://www.w3.org/ns/xproc-step" exclude-result-prefixes="#all">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.daisy.org/ns/xprocspec"
+    xmlns:c="http://www.w3.org/ns/xproc-step" exclude-result-prefixes="#all">
 
     <xsl:output indent="yes" method="xml"/>
 
     <xsl:template match="/x:description">
+        <xsl:variable name="documentation" select="x:documentation"/>
         <x:descriptions>
             <xsl:for-each select="//x:scenario">
                 <xsl:variable name="scenarios" select="ancestor-or-self::x:scenario"/>
                 <xsl:if test="not(descendant::x:scenario)">
                     <x:description>
                         <xsl:copy-of select="/*/@*"/>
+                        <xsl:copy-of select="$documentation"/>
                         <xsl:copy>
                             <xsl:copy-of select="$scenarios/@*"/>
                             <xsl:attribute name="label" select="string-join($scenarios/@label,' ')"/>
@@ -17,15 +20,27 @@
                             <xsl:if test="$pending">
                                 <xsl:attribute name="pending" select="$pending"/>
                             </xsl:if>
+                            <xsl:if test="$scenarios/x:documentation">
+                                <x:documentation>
+                                    <xsl:copy-of select="$scenarios/x:documentation/@*"/>
+                                    <xsl:copy-of select="$scenarios/x:documentation/node()"/>
+                                </x:documentation>
+                            </xsl:if>
                             <xsl:if test="$scenarios/x:call">
                                 <x:call>
                                     <xsl:copy-of select="$scenarios/x:call/@*"/>
+                                    <xsl:if test="$scenarios/x:call/x:documentation">
+                                        <x:documentation>
+                                            <xsl:copy-of select="$scenarios/x:call/x:documentation/@*"/>
+                                            <xsl:copy-of select="$scenarios/x:call/x:documentation/node()"/>
+                                        </x:documentation>
+                                    </xsl:if>
                                     <xsl:copy-of select="x:resolve-options($scenarios/x:call/x:option)"/>
                                     <xsl:copy-of select="x:resolve-params($scenarios/x:call/x:param)"/>
                                     <xsl:copy-of select="x:resolve-inputs($scenarios/x:call/x:input)"/>
                                 </x:call>
                             </xsl:if>
-                            <xsl:apply-templates select="* except x:call">
+                            <xsl:apply-templates select="* except (x:call | x:documentation)">
                                 <xsl:with-param name="pending-scenario" select="$pending" tunnel="yes"/>
                             </xsl:apply-templates>
                         </xsl:copy>
@@ -34,7 +49,7 @@
             </xsl:for-each>
         </x:descriptions>
     </xsl:template>
-    
+
     <xsl:template match="x:expect">
         <xsl:param name="pending-scenario" tunnel="yes" required="yes"/>
         <xsl:copy>
@@ -89,7 +104,7 @@
             </xsl:for-each>
         </xsl:copy>
     </xsl:template>
-    
+
     <xsl:function name="x:is-pending">
         <xsl:param name="this"/>
         <xsl:choose>
@@ -133,7 +148,8 @@
                     <xsl:sequence select="$param"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <x:param name="{$param/@name}" select="concat('&apos;',replace(replace(replace($param/@value,'&amp;','&amp;amp;'),&quot;'&quot;,&quot;&amp;apos;&quot;),'&quot;','&amp;quot;'),'&apos;')">
+                    <x:param name="{$param/@name}"
+                        select="concat('&apos;',replace(replace(replace($param/@value,'&amp;','&amp;amp;'),&quot;'&quot;,&quot;&amp;apos;&quot;),'&quot;','&amp;quot;'),'&apos;')">
                         <xsl:if test="$param/@namespace">
                             <xsl:attribute name="ns" select="$param/@namespace"/>
                         </xsl:if>

--- a/xprocspec/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
+++ b/xprocspec/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
@@ -530,7 +530,7 @@
                                 <p:empty/>
                             </p:with-option>
                         </pxi:perform-imports>
-                        
+
                         <!-- externalize inline script if present -->
                         <p:choose>
                             <p:when test="/*/x:script">
@@ -556,7 +556,7 @@
                                 <p:identity/>
                             </p:otherwise>
                         </p:choose>
-                        
+
                         <p:identity name="main-document"/>
 
                         <p:group>

--- a/xprocspec/src/main/resources/content/xml/xproc/report/report-to-html.xsl
+++ b/xprocspec/src/main/resources/content/xml/xproc/report/report-to-html.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns="http://www.w3.org/1999/xhtml" xmlns:html="http://www.w3.org/1999/xhtml" xpath-default-namespace="http://www.w3.org/1999/xhtml" exclude-result-prefixes="#all"
-    xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns="http://www.w3.org/1999/xhtml" xmlns:html="http://www.w3.org/1999/xhtml"
+    xpath-default-namespace="http://www.w3.org/1999/xhtml" exclude-result-prefixes="#all" xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:c="http://www.w3.org/ns/xproc-step"
+    xmlns:p="http://www.w3.org/ns/xproc" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <xsl:template match="html">
         <xsl:variable name="descriptions" select="body/x:description[not(x:scenario/@pending)]"/>
@@ -22,9 +23,22 @@
             <xsl:for-each select="head">
                 <xsl:copy>
                     <xsl:copy-of select="@*"/>
-                    <title>Test Report for <xsl:value-of select="$test-base-uri"/> (passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of select="$failed"/> / errors:<xsl:value-of
-                            select="$error-count"/> / total:<xsl:value-of select="$total"/>)</title>
+                    <title>Test Report for <xsl:value-of select="$test-base-uri"/> (passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of
+                            select="$failed"/> / errors:<xsl:value-of select="$error-count"/> / total:<xsl:value-of select="$total"/>)</title>
                     <xsl:copy-of select="node()"/>
+                    <style>
+                        .pp-tag-name{
+                            color:blue;
+                        }
+                        .pp-attr-name{
+                            color:orange;
+                        }
+                        .pp-attr-value{
+                            color:#FF4F4F;
+                        }
+                        .pp-document-element{
+                            background-color:#F5F5F5;
+                        }</style>
                 </xsl:copy>
             </xsl:for-each>
             <xsl:for-each select="body">
@@ -34,7 +48,7 @@
                     <p>Script: <a href="{$test-base-uri}"><xsl:value-of select="$test-base-uri"/></a></p>
                     <p>Tested: <xsl:value-of select="current-dateTime()"/><!-- TODO: prettier time: 10 July 2013 at 18:42 --></p>
                     <h2>Contents</h2>
-                    <table class="xspec">
+                    <table>
                         <col width="75%"/>
                         <col width="5%"/>
                         <col width="5%"/>
@@ -126,55 +140,11 @@
 
                     <xsl:if test="$errors">
                         <div id="errors">
-                            <h2 class="error">Errors<span class="scenario-totals">passed:0 / pending:0 / failed:0 / errors:<xsl:value-of select="$error-count"/> / total:<xsl:value-of select="$error-count"/></span></h2>
-                            <table class="xspec">
-                                <col width="80%"/>
-                                <col width="20%"/>
-                                <tbody>
-                                    <!-- for each static error group -->
-                                    <xsl:for-each select="$errors">
-                                        <xsl:variable name="error-location" select="@error-location"/>
-                                        <xsl:variable name="test-base-uri" select="@test-base-uri"/>
-                                        <xsl:variable name="test-grammar" select="@test-grammar"/>
-                                        <xsl:variable name="errors" select="c:error"/>
-
-                                        <tr class="error label">
-                                            <th>
-                                                <xsl:value-of select="$error-location"/>
-                                                <br/>
-                                                <br/>
-                                            </th>
-                                            <th class="nobr">Error</th>
-                                        </tr>
-
-                                        <!-- for each step error in current error group -->
-                                        <xsl:for-each select="$errors">
-                                            <xsl:variable name="name" select="@name"/>
-                                            <xsl:variable name="type" select="@type"/>
-                                            <xsl:variable name="code" select="@code"/>
-                                            <xsl:variable name="href" select="@href"/>
-                                            <xsl:variable name="line" select="@line"/>
-                                            <xsl:variable name="column" select="@column"/>
-                                            <xsl:variable name="offset" select="@offset"/>
-                                            <xsl:variable name="content" select="node()"/>
-
-                                            <tr class="error">
-                                                <td colspan="2">
-                                                    <xsl:value-of select="if ($href) then concat($href,' ') else ''"/>
-                                                    <xsl:value-of select="if ($line) then concat('line:',$line,' ') else ''"/>
-                                                    <xsl:value-of select="if ($column) then concat('column:',$column,' ') else ''"/>
-                                                    <xsl:value-of select="if ($offset) then concat('offset:',$offset,' ') else ''"/>
-                                                    <xsl:value-of select="if ($code) then concat('code:',$code,' ') else ''"/>
-                                                    <xsl:value-of select="if ($type) then concat('type:',$type,' ') else ''"/>
-                                                    <xsl:if test="* or normalize-space(string-join(node(),''))">
-                                                        <pre><code><xsl:copy-of select="node()"/></code></pre>
-                                                    </xsl:if>
-                                                </td>
-                                            </tr>
-                                        </xsl:for-each>
-                                    </xsl:for-each>
-                                </tbody>
-                            </table>
+                            <h2 class="error">Errors<span class="scenario-totals">passed:0 / pending:0 / failed:0 / errors:<xsl:value-of select="$error-count"/> / total:<xsl:value-of
+                                        select="$error-count"/></span></h2>
+                            <xsl:for-each select="$errors">
+                                <xsl:call-template name="print-context"/>
+                            </xsl:for-each>
                         </div>
                     </xsl:if>
 
@@ -192,9 +162,9 @@
                         <xsl:variable name="script-base" select="($step-descriptions/resolve-uri(@script,base-uri()))[1]"/>
 
                         <div id="{$stepid}">
-                            <h2 class="{$step-class}">Calling: <a href="{$script-base}"><xsl:value-of select="$step-shortname"/></a><span class="scenario-totals">passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> /
-                                        failed:<xsl:value-of select="$failed"/> / errors:0 / total:<xsl:value-of select="$total"/></span></h2>
-                            <table class="xspec">
+                            <h2 class="{$step-class}">Calling: <a href="{$script-base}"><xsl:value-of select="$step-shortname"/></a><span class="scenario-totals">passed:<xsl:value-of select="$passed"
+                                    /> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of select="$failed"/> / errors:0 / total:<xsl:value-of select="$total"/></span></h2>
+                            <table>
                                 <col width="80%"/>
                                 <col width="20%"/>
                                 <tbody>
@@ -214,7 +184,8 @@
                                             <th class="scenario-label">
                                                 <xsl:value-of select="$scenario-description/x:scenario/@label"/>
                                             </th>
-                                            <th class="nobr">passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of select="$failed"/> / errors:0 / total:<xsl:value-of select="$total"/></th>
+                                            <th class="nobr">passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of select="$failed"/> / errors:0 /
+                                                    total:<xsl:value-of select="$total"/></th>
                                         </tr>
 
                                         <!-- for each step scenario context -->
@@ -231,7 +202,8 @@
                                                 <th class="context-label">
                                                     <xsl:value-of select="@label"/>
                                                 </th>
-                                                <th class="nobr">passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of select="$failed"/> / errors:0 / total:<xsl:value-of select="$total"/></th>
+                                                <th class="nobr">passed:<xsl:value-of select="$passed"/> / pending:<xsl:value-of select="$pending"/> / failed:<xsl:value-of select="$failed"/> /
+                                                    errors:0 / total:<xsl:value-of select="$total"/></th>
                                             </tr>
                                             <xsl:if test="$context-class='failed'">
                                                 <tr class="was">
@@ -249,7 +221,7 @@
                                                     <xsl:otherwise>
                                                         <tr class="was">
                                                             <td colspan="2">
-                                                                <pre><code><xsl:copy-of select="node()"/></code></pre>
+                                                                <xsl:call-template name="print-context"/>
                                                             </td>
                                                         </tr>
                                                     </xsl:otherwise>
@@ -258,8 +230,10 @@
 
                                             <!-- for each step scenario context test -->
                                             <xsl:for-each select="$context-tests">
-                                                <xsl:variable name="test-class" select="if (@result='failed') then 'failed' else if (@result='skipped') then 'pending' else if (@result='passed') then 'successful' else ''"/>
-                                                <xsl:variable name="test-result" select="if (@result='failed') then 'Failed' else if (@result='skipped') then 'Pending' else if (@result='passed') then 'Success' else '[Unknown]'"/>
+                                                <xsl:variable name="test-class"
+                                                    select="if (@result='failed') then 'failed' else if (@result='skipped') then 'pending' else if (@result='passed') then 'successful' else ''"/>
+                                                <xsl:variable name="test-result"
+                                                    select="if (@result='failed') then 'Failed' else if (@result='skipped') then 'Pending' else if (@result='passed') then 'Success' else '[Unknown]'"/>
                                                 <tr class="{$test-class} label">
                                                     <td class="test-label">
                                                         <xsl:value-of select="@label"/>
@@ -279,12 +253,38 @@
                                                 <xsl:if test="$test-class='failed'">
                                                     <tr class="expected">
                                                         <td colspan="2">
-                                                            <xsl:if test="x:was">
-                                                                <div>Test: <pre><code><xsl:copy-of select="x:was/node()"/></code></pre></div>
-                                                            </xsl:if>
-                                                            <xsl:if test="x:expected">
-                                                                <div>Equals: <pre><code><xsl:copy-of select="x:expected/node()"/></code></pre></div>
-                                                            </xsl:if>
+                                                            <xsl:variable name="was" select="x:was"/>
+                                                            <xsl:variable name="expected" select="x:expected"/>
+                                                            <table>
+                                                                <col width="50%"/>
+                                                                <col width="50%"/>
+                                                                <thead>
+                                                                    <tr>
+                                                                        <th>Result</th>
+                                                                        <th>Expected</th>
+                                                                    </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                                    <xsl:for-each select="1 to max((count($was),count($expected)))">
+                                                                        <xsl:variable name="pos" select="."/>
+                                                                        <xsl:variable name="this-was" select="$was[.]"/>
+                                                                        <xsl:variable name="this-expected" select="$expected[.]"/>
+
+                                                                        <tr>
+                                                                            <td>
+                                                                                <xsl:for-each select="$this-was">
+                                                                                    <xsl:call-template name="print-context"/>
+                                                                                </xsl:for-each>
+                                                                            </td>
+                                                                            <td>
+                                                                                <xsl:for-each select="$this-expected">
+                                                                                    <xsl:call-template name="print-context"/>
+                                                                                </xsl:for-each>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </xsl:for-each>
+                                                                </tbody>
+                                                            </table>
                                                         </td>
                                                     </tr>
                                                 </xsl:if>
@@ -297,15 +297,14 @@
                     </xsl:for-each>
 
                     <!-- for each script with pending scenarios -->
-                    <!--<xsl:for-each select="distinct-values($pending-descriptions/resolve-uri(@script,base-uri()))">-->
                     <xsl:for-each select="distinct-values($pending-descriptions/(x:step-declaration/*/@type,resolve-uri(@script,base-uri()))[1])">
                         <xsl:variable name="title" select="."/>
                         <xsl:variable name="pending-script-descriptions" select="$pending-descriptions[(x:step-declaration/*/@type,resolve-uri(@script,base-uri()))[1] = $title]"/>
                         <xsl:variable name="script-base" select="($pending-script-descriptions/resolve-uri(@script,base-uri()))[1]"/>
                         <div id="pending-{count($pending-script-descriptions[1]/preceding::x:description)}">
-                            <h2 class="pending">Not calling: <a href="{$script-base}"><xsl:value-of select="$title"/></a><span class="scenario-totals">passed:0 / pending:<xsl:value-of select="count($pending-script-descriptions)"/> / failed:0 /
-                                    errors:0 / total:<xsl:value-of select="count($pending-script-descriptions)"/></span></h2>
-                            <table class="xspec">
+                            <h2 class="pending">Not calling: <a href="{$script-base}"><xsl:value-of select="$title"/></a><span class="scenario-totals">passed:0 / pending:<xsl:value-of
+                                        select="count($pending-script-descriptions)"/> / failed:0 / errors:0 / total:<xsl:value-of select="count($pending-script-descriptions)"/></span></h2>
+                            <table>
                                 <col width="80%"/>
                                 <col width="20%"/>
                                 <tbody>
@@ -331,46 +330,423 @@
 
                     <xsl:if test="$log">
                         <h2>Execution log</h2>
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Time</th>
-                                    <th>Severity</th>
-                                    <th>Message</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <xsl:for-each select="$log/c:line">
-                                    <tr
-                                        style="{if (@severity='DEBUG') then 'color:#696969;' else if (@severity='INFO') then '' else if (@severity='WARN') then 'background-color:#FFD700;' else if (@severity='ERROR') then 'background-color:#FF6347;' else ''}">
-                                        <td>
-                                            <xsl:variable name="t" select="replace(string(xs:dateTime(@time)-xs:dateTime($log/c:line[1]/@time)),'[^\d\.]','')"/>
-                                            <xsl:variable name="t" select="tokenize($t,'\.')"/>
-                                            <xsl:variable name="t" select="if (count($t)=1) then concat($t,'.000') else concat($t[1],'.',$t[2], string-join(for $pad in (string-length($t[2]) to 2) return '0', ''))"/>
-                                            <xsl:value-of select="$t"/>
-                                        </td>
-                                        <td style="padding-left:0%;">
-                                            <xsl:value-of select="@severity"/>
-                                        </td>
-                                        <td>
-                                            <code>
-                                                <pre><xsl:value-of select="./text()"/></pre>
-                                            </code>
-                                        </td>
-                                    </tr>
-                                </xsl:for-each>
-                            </tbody>
-                        </table>
+                        <xsl:apply-templates select="$log"/>
                     </xsl:if>
 
-                    <!--<script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js?autoload=true&amp;lang=xml">;</script>-->
-                    <link rel="stylesheet" href="http://yandex.st/highlightjs/7.3/styles/default.min.css"/>
-                    <script type="text/javascript" src="http://yandex.st/highlightjs/7.3/highlight.min.js" xml:space="preserve"> </script>
-                    <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
                 </xsl:copy>
             </xsl:for-each>
 
         </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="c:log">
+        <xsl:variable name="log" select="."/>
+        <table>
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>Severity</th>
+                    <th>Message</th>
+                </tr>
+            </thead>
+            <tbody>
+                <xsl:for-each select="$log/c:line">
+                    <tr
+                        style="{if (@severity='DEBUG') then 'color:#696969;' else if (@severity='INFO') then '' else if (@severity='WARN') then 'background-color:#FFD700;' else if (@severity='ERROR') then 'background-color:#FF6347;' else ''}">
+                        <td>
+                            <xsl:variable name="t" select="replace(string(xs:dateTime(@time)-xs:dateTime($log/c:line[1]/@time)),'[^\d\.]','')"/>
+                            <xsl:variable name="t" select="tokenize($t,'\.')"/>
+                            <xsl:variable name="t" select="if (count($t)=1) then concat($t,'.000') else concat($t[1],'.',$t[2], string-join(for $pad in (string-length($t[2]) to 2) return '0', ''))"/>
+                            <xsl:value-of select="$t"/>
+                        </td>
+                        <td style="padding-left:0%;">
+                            <xsl:value-of select="@severity"/>
+                        </td>
+                        <td>
+                            <code>
+                                <pre><xsl:value-of select="./text()"/></pre>
+                            </code>
+                        </td>
+                    </tr>
+                </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
+
+    <xsl:template match="p:* | c:*">
+        <div class="pp-xml">
+            <xsl:call-template name="pretty-print"/>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="x:description">
+        <h3>xprocspec document metadata</h3>
+        <div style="padding-left: 50px;">
+            <dl>
+                <xsl:for-each select="@*">
+                    <dt>
+                        <xsl:value-of select="name()"/>
+                    </dt>
+                    <dd>
+                        <xsl:value-of select="string(.)"/>
+                    </dd>
+                </xsl:for-each>
+            </dl>
+            <xsl:apply-templates select="x:documentation | x:step-declaration | x:scenario"/>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="x:*">
+        <h3>
+            <xsl:variable name="name" select="local-name()"/>
+            <xsl:choose>
+                <xsl:when test="$name='step-declaration'">
+                    <xsl:text>XProc step declaration</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='scenario'">
+                    <xsl:text>Scenario</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='call'">
+                    <xsl:text>Invocation</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='option'">
+                    <xsl:text>Option</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='param'">
+                    <xsl:text>Parameter</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='input'">
+                    <xsl:text>Input port</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='context'">
+                    <xsl:text>Test context</xsl:text>
+                </xsl:when>
+                <xsl:when test="$name='expect'">
+                    <xsl:text>Assertion</xsl:text>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="name()"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </h3>
+        <div style="padding-left: 50px;">
+            <dl>
+                <xsl:for-each select="@*">
+                    <dt>
+                        <xsl:value-of select="name()"/>
+                    </dt>
+                    <dd>
+                        <xsl:value-of select="string(.)"/>
+                    </dd>
+                </xsl:for-each>
+            </dl>
+            <xsl:for-each select="node()">
+                <xsl:choose>
+                    <xsl:when test="self::x:* | self::c:*">
+                        <xsl:apply-templates select="."/>
+                    </xsl:when>
+                    <xsl:when test="self::*">
+                        <div class="pp-xml">
+                            <xsl:call-template name="pretty-print"/>
+                        </div>
+                    </xsl:when>
+                    <xsl:when test="self::text() and normalize-space(.)!=''">
+                        <pre><code><xsl:copy-of select="."/></code></pre>
+                    </xsl:when>
+                    <xsl:otherwise/>
+                </xsl:choose>
+            </xsl:for-each>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="x:documentation">
+        <xsl:variable name="describes" select="parent::*/local-name()"/>
+        <div style="padding-left: 50px;">
+            <h4>
+                <xsl:choose>
+                    <xsl:when test="$describes='description'">
+                        <xsl:text>Description of xprocspec document:</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='step-declaration'">
+                        <xsl:text>Description of XProc step declaration</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='scenario'">
+                        <xsl:text>Description of scenario:</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='call'">
+                        <xsl:text>Description of invocation (inputs/options/parameters):</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='option'">
+                        <xsl:text>Description of option</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='param'">
+                        <xsl:text>Description of parameter</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='input'">
+                        <xsl:text>Description of input port</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='context'">
+                        <xsl:text>Description of test context:</xsl:text>
+                    </xsl:when>
+                    <xsl:when test="$describes='expect'">
+                        <xsl:text>Description of assertion:</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$describes"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </h4>
+            <div style="padding-left: 50px;">
+                <xsl:copy-of select="node()"/>
+            </div>
+        </div>
+    </xsl:template>
+
+    <xsl:template match="x:test-report">
+        <h2>Test report</h2>
+        <xsl:for-each select="node()">
+            <xsl:choose>
+                <xsl:when test="self::x:* | self::c:*">
+                    <xsl:apply-templates select="."/>
+                </xsl:when>
+                <xsl:when test="self::*">
+                    <div class="pp-xml">
+                        <xsl:call-template name="pretty-print"/>
+                    </div>
+                </xsl:when>
+                <xsl:when test="self::text() and normalize-space(.)!=''">
+                    <pre><code><xsl:copy-of select="."/></code></pre>
+                </xsl:when>
+                <xsl:otherwise/>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="x:document">
+        <xsl:param name="include-raw" select="false()" tunnel="yes"/>
+        <xsl:if test="@xml:base">
+            <p>Document base URI: <code><xsl:value-of select="@xml:base"/></code></p>
+        </xsl:if>
+        <xsl:choose>
+            <xsl:when test="@type='inline' or not(@type)">
+                <xsl:for-each select="*">
+                    <xsl:choose>
+                        <xsl:when test="self::x:* | self::c:*">
+                            <xsl:apply-templates select="."/>
+                            <xsl:if test="$include-raw">
+                                <div class="pp-xml">
+                                    <xsl:call-template name="pretty-print"/>
+                                </div>
+                            </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <div class="pp-xml">
+                                <xsl:call-template name="pretty-print"/>
+                            </div>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:for-each>
+            </xsl:when>
+            <xsl:otherwise>
+                <dl>
+                    <xsl:for-each select="@*">
+                        <dt>
+                            <xsl:value-of select="name()"/>
+                        </dt>
+                        <dd>
+                            <xsl:value-of select="string(.)"/>
+                        </dd>
+                    </xsl:for-each>
+                </dl>
+                <xsl:for-each select="node()">
+                    <xsl:choose>
+                        <xsl:when test="self::x:* | self::c:*">
+                            <xsl:apply-templates select="."/>
+                            <xsl:if test="$include-raw">
+                                <div class="pp-xml">
+                                    <xsl:call-template name="pretty-print"/>
+                                </div>
+                            </xsl:if>
+                        </xsl:when>
+                        <xsl:when test="self::* and $include-raw">
+                            <div class="pp-xml">
+                                <xsl:call-template name="pretty-print"/>
+                            </div>
+                        </xsl:when>
+                        <xsl:when test="self::text() and normalize-space(.)!='' and $include-raw">
+                            <pre><code><xsl:copy-of select="."/></code></pre>
+                        </xsl:when>
+                        <xsl:otherwise/>
+                    </xsl:choose>
+                </xsl:for-each>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="c:errors">
+        <p><xsl:value-of select="count(c:error)"/> errors found.</p>
+        <dl>
+            <xsl:for-each select="@*">
+                <dt>
+                    <xsl:value-of select="name()"/>
+                </dt>
+                <dd>
+                    <xsl:value-of select="string(.)"/>
+                </dd>
+            </xsl:for-each>
+        </dl>
+        <xsl:for-each select="node()">
+            <xsl:choose>
+                <xsl:when test="self::x:* | self::c:*">
+                    <xsl:apply-templates select="."/>
+                </xsl:when>
+                <xsl:when test="self::*">
+                    <div class="pp-xml">
+                        <xsl:call-template name="pretty-print"/>
+                    </div>
+                </xsl:when>
+                <xsl:otherwise>
+                    <pre><code><xsl:copy-of select="."/></code></pre>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="c:error">
+        <div style="border:2px solid;border-radius:5px;">
+            <dl>
+                <xsl:for-each select="@*">
+                    <dt>
+                        <xsl:value-of select="name()"/>
+                    </dt>
+                    <dd>
+                        <xsl:value-of select="string(.)"/>
+                    </dd>
+                </xsl:for-each>
+            </dl>
+            <xsl:for-each select="node()">
+                <xsl:choose>
+                    <xsl:when test="self::*">
+                        <div class="pp-xml">
+                            <xsl:call-template name="pretty-print"/>
+                        </div>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <pre><code><xsl:copy-of select="."/></code></pre>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each>
+        </div>
+    </xsl:template>
+
+    <xsl:template name="pretty-print">
+        <xsl:param name="indent" select="0"/>
+        <xsl:element name="{if ($indent=0) then 'div' else 'span'}">
+            <xsl:attribute name="class" select="if ($indent=0) then 'pp-element pp-document-element' else 'pp-element'"/>
+            <xsl:choose>
+                <xsl:when test="self::x:was | self::x:expected">
+                    <xsl:for-each select="node()">
+                        <xsl:call-template name="pretty-print"/>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:when test="self::text()">
+                    <pre><code><xsl:value-of select="."/></code></pre>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:variable name="indent-spaces" select="string-join(for $i in (1 to $indent) return '&#160;&#160;&#160;&#160;','')"/>
+                    <br/>
+                    <xsl:value-of select="$indent-spaces"/>
+                    <span class="pp-tag-open">&lt;</span>
+                    <span class="pp-tag-name">
+                        <xsl:value-of select="local-name()"/>
+                    </span>
+                    <xsl:if test="$indent=0 or not(namespace-uri()=parent::*/namespace-uri())">
+                        <xsl:text> </xsl:text>
+                        <span class="pp-attr-name">xmlns=</span>
+                        <span class="pp-attr-value">
+                            <xsl:text>"</xsl:text>
+                            <xsl:value-of select="namespace-uri()"/>
+                            <xsl:text>"</xsl:text>
+                        </span>
+                    </xsl:if>
+                    <xsl:for-each select="@*">
+                        <xsl:text> </xsl:text>
+                        <span class="pp-attr-name">
+                            <xsl:value-of select="name()"/>
+                            <xsl:text>=</xsl:text>
+                        </span>
+                        <span class="pp-attr-value">
+                            <xsl:text>"</xsl:text>
+                            <xsl:value-of select="string(.)"/>
+                            <xsl:text>"</xsl:text>
+                        </span>
+                    </xsl:for-each>
+                    <xsl:choose>
+                        <xsl:when test="not(node())">
+                            <span class="pp-tag-close">/&gt;</span>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <span class="pp-tag-close">&gt;</span>
+                            <xsl:for-each select="node()">
+                                <xsl:choose>
+                                    <xsl:when test="self::*">
+                                        <xsl:call-template name="pretty-print">
+                                            <xsl:with-param name="indent" select="$indent+1"/>
+                                        </xsl:call-template>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:copy-of select="."/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:for-each>
+                            <xsl:if test="*">
+                                <br/>
+                                <xsl:value-of select="$indent-spaces"/>
+                            </xsl:if>
+                            <span class="pp-tag-open">&lt;</span>
+                            <xsl:text>/</xsl:text>
+                            <span class="pp-tag-name">
+                                <xsl:value-of select="local-name()"/>
+                            </span>
+                            <span class="pp-tag-close">&gt;</span>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:element>
+        <xsl:if test="$indent=0">
+            <br/>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="print-context">
+        <xsl:choose>
+            <xsl:when test="not(*)">
+                <pre><code><xsl:copy-of select="."/></code></pre>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:for-each select="node()">
+                    <xsl:choose>
+                        <xsl:when test="self::text() and normalize-space(.)=''"/>
+                        <xsl:when test="self::x:document">
+                            <xsl:apply-templates select=".">
+                                <xsl:with-param name="include-raw" select="true()" tunnel="yes"/>
+                            </xsl:apply-templates>
+                        </xsl:when>
+                        <xsl:when test="self::x:* | self::c:*">
+                            <xsl:apply-templates select=".">
+                                <xsl:with-param name="include-raw" select="true()" tunnel="yes"/>
+                            </xsl:apply-templates>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <div class="pp-xml">
+                                <xsl:call-template name="pretty-print"/>
+                            </div>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:for-each>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/xprocspec/src/main/resources/content/xml/xproc/report/report.xpl
+++ b/xprocspec/src/main/resources/content/xml/xproc/report/report.xpl
@@ -60,9 +60,6 @@
             </p:input>
         </p:xslt>
     </p:viewport>
-    <p:viewport match="c:error | x:expected | x:was | x:document">
-        <p:escape-markup/>
-    </p:viewport>
     <p:xslt>
         <p:input port="parameters">
             <p:empty/>


### PR DESCRIPTION
The errors should now be better formatted in the HTML report. fixes #11 - I'm not sure if they are good enough - anyone can feel free to open the issue again and specify what needs more improvement.

A new `x:documentation` element is added. fixes #10 - it should make it easy to document and generate documentation for xprocspec documents.
