### PR TITLE
Allow focus on x:description

### DIFF
--- a/xprocspec/catalog.xml
+++ b/xprocspec/catalog.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+   <nextCatalog catalog="src/main/resources/META-INF/catalog.xml"/>
+</catalog>

--- a/xprocspec/src/main/resources/content/xml/schema/xprocspec.rng
+++ b/xprocspec/src/main/resources/content/xml/schema/xprocspec.rng
@@ -55,6 +55,9 @@
         <optional>
             <ref name="pending-attribute"/>
         </optional>
+        <optional>
+            <ref name="focus-attribute"/>
+        </optional>
     </define>
 
     <define name="script">

--- a/xprocspec/src/test/xprocspec/tests/regression-tests/issue-4_temp-dir-option.xprocspec
+++ b/xprocspec/src/test/xprocspec/tests/regression-tests/issue-4_temp-dir-option.xprocspec
@@ -2,17 +2,17 @@
 <?xml-model href="http://www.daisy.org/ns/xprocspec/xprocspec.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <x:description xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:ex="http://example.net/ns" script="../../steps/temp-dir-option.xpl">
 
-    <x:scenario label="temp-dir">
+    <x:scenario label="temp-dir" pending="Not clear yet whether this is a bug or not; see #44">
         <x:call step="ex:temp-dir-option">
             <x:option name="temp-dir" select="'xprocspec temp-dir value'"/>
-            <x:option name="output-dir" select="'xprocspec output-dir value'"/>
+            <x:option name="output-dir" select="$temp-dir"/>
         </x:call>
         <x:context label="the result">
             <x:document type="port" port="result"/>
         </x:context>
         <x:expect type="count" label="there should be one document on the result port" min="1" max="1"/>
-        <x:expect type="xpath" label="the value of the temp-dir attribute should be 'xprocspec temp-dir value'" test="/*/@temp-dir" equals="'xprocspec temp-dir value'"/>
-        <x:expect type="xpath" label="the value of the output-dir attribute should be 'xprocspec output-dir value'" test="/*/@output-dir" equals="'xprocspec output-dir value'"/>
+        <x:expect type="xpath" label="the value of the output-dir option should not equal the temp-dir value" test="/*/@output-dir" equals="/*/@temp-dir" xfail="true"/>
+        <x:expect type="xpath" label="the value of the $temp-dir variable should not equal the temp-dir value" test="$temp-dir" equals="/*/@temp-dir" xfail="true"/>
     </x:scenario>
 
 </x:description>


### PR DESCRIPTION
See issue https://github.com/daisy/xprocspec/issues/45

<!---
@huboard:{"order":0.0009752938569777169,"milestone_order":8.994601889496115,"custom_state":""}
-->
