### PR TITLE
Release 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>v1.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.3.0</tag>
     </scm>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                 <dependency>
                   <groupId>org.daisy.maven</groupId>
                   <artifactId>xproc-engine-calabash</artifactId>
-                  <version>1.0.0</version>
+                  <version>1.1.0</version>
                 </dependency>
                 <dependency>
                   <groupId>nu.validator.htmlparser</groupId>

--- a/src/main/resources/content/xml/schema/xprocspec.rng
+++ b/src/main/resources/content/xml/schema/xprocspec.rng
@@ -703,6 +703,34 @@
                     </optional>
                 </group>
                 <group>
+                    <!-- zip -->
+                    <attribute name="type">
+                        <a:documentation xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve">
+                            If the `type` attribute is `zip`, then the `document` element will be
+                            replaced with a listing of the ZIP file pointed to by the `href`
+                            attribute. The `href` URI is by default resolved against the base URI of
+                            the xprocspec test document. However, if you provide the `base-uri`
+                            attribute with a value of `temp-dir`, then the `href` URI will be
+                            resolved against the temporary directory used for the test instead.
+                        </a:documentation>
+                        <value>directory</value>
+                    </attribute>
+                    <attribute name="href">
+                        <a:documentation xmlns="http://www.w3.org/1999/xhtml">When `type` is `zip`;
+                        the `href` attribute is a URI pointing to the ZIP file you want
+                        listed.</a:documentation>
+                        <data type="anyURI"/>
+                    </attribute>
+                    <optional>
+                        <attribute name="base-uri">
+                            <a:documentation xmlns="http://www.w3.org/1999/xhtml"><!-- documented in the "inline" group --></a:documentation>
+                            <choice>
+                                <value>temp-dir</value>
+                            </choice>
+                        </attribute>
+                    </optional>
+                </group>
+                <group>
                     <!-- errors -->
                     <attribute name="type">
                         <a:documentation xmlns="http://www.w3.org/1999/xhtml" xml:space="preserve">

--- a/src/main/resources/content/xml/schema/xprocspec.rng
+++ b/src/main/resources/content/xml/schema/xprocspec.rng
@@ -722,6 +722,14 @@
                         <data type="anyURI"/>
                     </attribute>
                     <optional>
+                        <attribute name="ordered">
+                            <a:documentation xmlns="http://www.w3.org/1999/xhtml">When `ordered` is
+                            `true`, the ZIP entries are listed in lexicographical
+                            order.</a:documentation>
+                            <data type="boolean"/>
+                        </attribute>
+                    </optional>
+                    <optional>
                         <attribute name="base-uri">
                             <a:documentation xmlns="http://www.w3.org/1999/xhtml"><!-- documented in the "inline" group --></a:documentation>
                             <choice>

--- a/src/main/resources/content/xml/xproc/compile/description-to-invocation.xsl
+++ b/src/main/resources/content/xml/xproc/compile/description-to-invocation.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:c="http://www.w3.org/ns/xproc-step">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0" xmlns:p="http://www.w3.org/ns/xproc" xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:dpx="http://www.daisy.org/ns/pipeline/xproc">
 
     <xsl:output indent="yes" method="xml"/>
     <xsl:param name="test-base-uri" required="yes"/>
@@ -52,7 +52,7 @@
                 <xsl:otherwise>
                     <xsl:text>
     </xsl:text>
-                    <p:try>
+                    <p:try dpx:progress="1">
                         <xsl:text>
         </xsl:text>
                         <p:group>
@@ -60,6 +60,7 @@
         </xsl:text>
                             <xsl:element name="{replace(/*/x:step-declaration/*/@type,'.*\}','')}" namespace="{replace(/*/x:step-declaration/*/@x:type,'^\{(.*)\}.*$','$1')}">
                                 <xsl:attribute name="name" select="'test'"/>
+                                <xsl:attribute name="dpx:progress" select="'1'"/>
                                 <xsl:for-each select="/*/x:scenario/x:call/x:option">
                                     <xsl:text>
         </xsl:text>

--- a/src/main/resources/content/xml/xproc/run/run.xpl
+++ b/src/main/resources/content/xml/xproc/run/run.xpl
@@ -1,4 +1,4 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="pxi:test-run" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/"
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="pxi:test-run" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" xmlns:dpx="http://www.daisy.org/ns/pipeline/xproc"
     version="1.0" xpath-version="2.0" xmlns:x="http://www.daisy.org/ns/xprocspec">
 
     <p:input port="source" sequence="true"/>
@@ -14,7 +14,7 @@
     <p:import href="../utils/logging-library.xpl"/>
     <p:import href="../utils/validate-with-relax-ng.xpl"/>
     
-    <p:for-each>
+    <p:for-each dpx:progress="1">
         <pxi:message message="   * loading '$1'">
             <p:with-option name="param1" select="string(/*)"/>
             <p:with-option name="logfile" select="$logfile">
@@ -24,7 +24,7 @@
         <p:load name="test">
             <p:with-option name="href" select="/*"/>
         </p:load>
-        <p:choose>
+        <p:choose dpx:message=" " dpx:progress="1">
             <p:when test="/*[self::c:errors]">
                 <pxi:message message=" * error document; skipping">
                     <p:with-option name="logfile" select="$logfile">
@@ -36,9 +36,9 @@
             <p:otherwise>
                 <p:variable name="test-href" select="(//x:description)[1]/@test-base-uri"/>
                 <p:identity name="try.input"/>
-                <p:try>
+                <p:try dpx:progress="1">
                     <p:group>
-                        <cx:eval>
+                        <cx:eval dpx:progress="1">
                             <p:input port="pipeline">
                                 <p:pipe port="result" step="test"/>
                             </p:input>

--- a/src/main/resources/content/xml/xproc/utils/document.xpl
+++ b/src/main/resources/content/xml/xproc/utils/document.xpl
@@ -24,6 +24,7 @@
     <p:variable name="href" select="resolve-uri(/*/@href, $base-dir)"/>
     <p:variable name="method" select="if (/*/@method=('xml','html','text','binary')) then /*/@method else 'xml'"/>
     <p:variable name="recursive" select="if (/*/@recursive=('true','false')) then /*/@recursive else 'false'"/>
+    <p:variable name="ordered" select="/*/@ordered"/>
 
     <p:identity>
         <p:input port="source">
@@ -225,6 +226,21 @@
                     <p:label-elements match="/c:zipfile" attribute="name" label="replace(@href,'^.*/([^/]*)$','$1')"/>
                     <p:delete match="c:directory"/>
                     <p:delete match="@*[not(namespace-uri()='' and local-name()='name')]"/>
+                    <p:choose>
+                        <p:when test="$ordered='true'">
+                            <p:xslt>
+                                <p:input port="stylesheet">
+                                    <p:document href="sort-zip-entries.xsl"/>
+                                </p:input>
+                                <p:input port="parameters">
+                                    <p:empty/>
+                                </p:input>
+                            </p:xslt>
+                        </p:when>
+                        <p:otherwise>
+                            <p:identity/>
+                        </p:otherwise>
+                    </p:choose>
                     <p:wrap-sequence wrapper="x:document"/>
                     <p:add-attribute match="/*" attribute-name="xml:base">
                         <p:with-option name="attribute-value" select="$href"/>

--- a/src/main/resources/content/xml/xproc/utils/html-load.xpl
+++ b/src/main/resources/content/xml/xproc/utils/html-load.xpl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <p:declare-step type="pxi:html-load" xmlns:p="http://www.w3.org/ns/xproc"
-    xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+    xmlns:c="http://www.w3.org/ns/xproc-step"
     xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/"
     xmlns:cx="http://xmlcalabash.com/ns/extensions" exclude-inline-prefixes="#all" version="1.0">
     <p:documentation>Tries first to p:load the HTML-file. An exception will be thrown if the file is

--- a/src/main/resources/content/xml/xproc/utils/sort-zip-entries.xsl
+++ b/src/main/resources/content/xml/xproc/utils/sort-zip-entries.xsl
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+                xmlns:c="http://www.w3.org/ns/xproc-step">
+	
+	<xsl:template match="@*|node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"/>
+		</xsl:copy>
+	</xsl:template>
+	
+	<xsl:template match="/c:zipfile">
+		<xsl:copy>
+			<xsl:sequence select="@*"/>
+			<xsl:apply-templates select="c:file">
+				<xsl:sort select="@name"/>
+			</xsl:apply-templates>
+		</xsl:copy>
+	</xsl:template>
+	
+</xsl:stylesheet>

--- a/src/main/resources/content/xml/xproc/xprocspec.xpl
+++ b/src/main/resources/content/xml/xproc/xprocspec.xpl
@@ -1,5 +1,6 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="px:xprocspec" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step"
-    xmlns:px="http://www.daisy.org/ns/xprocspec" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" exclude-inline-prefixes="#all" version="1.0" xpath-version="2.0"
+    xmlns:px="http://www.daisy.org/ns/xprocspec" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" xmlns:dpx="http://www.daisy.org/ns/pipeline/xproc"
+    exclude-inline-prefixes="#all" version="1.0" xpath-version="2.0"
     xmlns:pkg="http://expath.org/ns/pkg" pkg:import-uri="http://www.daisy.org/ns/xprocspec/xprocspec.xpl">
 
     <p:input port="source" sequence="true"/>
@@ -144,7 +145,7 @@
             <p:empty/>
         </p:with-option>
     </pxi:message>
-    <pxi:test-run name="run">
+    <pxi:test-run name="run" dpx:progress="1">
         <p:with-option name="logfile" select="$logfile">
             <p:empty/>
         </p:with-option>

--- a/www/documentation/generated.html
+++ b/www/documentation/generated.html
@@ -355,16 +355,21 @@
 
 
 <section id="the-document-element">
-<h2>The <code>document</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd>One element from any namespace. (optional)</dd><dt>Content attributes:</dt><dd><a href="#attr-document-base-uri"><code>base-uri</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-method"><code>method</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-port"><code>port</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-position"><code>position</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-recursive"><code>recursive</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-select"><code>select</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
+<h2>The <code>document</code> element</h2><dl class="element"><dt>Content model:</dt><dd><a href="#the-documentation-element"><code>documentation</code></a><small title="optional">?</small></dd><dd>One element from any namespace. (optional)</dd><dt>Content attributes:</dt><dd><a href="#attr-document-base-uri"><code>base-uri</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-href"><code>href</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-method"><code>method</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-ordered"><code>ordered</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-port"><code>port</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-position"><code>position</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-recursive"><code>recursive</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-select"><code>select</code></a><small title="optional">?</small></dd><dd><a href="#attr-document-type"><code>type</code></a><small title="optional">?</small></dd><dd>Zero or more attributes from any namespace.</dd></dl>
 <p>The <a href="#the-document-element"><code>document</code></a> element is used to define which documents are provided on a steps input ports, what the context is when making assertions, and for assertions when making comparisons
                     or performing validations. It can be used in a number of ways:</p>
 
 <p id="attr-document-base-uri">If the <code>base-uri</code> attribute is <code>temp-dir</code>, then the URI in the <a href="#attr-document-href"><code>href</code></a> attribute (or the xml:base attribute of the
                                 <code>document</code> or inline element in the case of inline documents) will be resolved against the temporary directory used for the test, instead of the base URI of the
-                                xprocspec document.</p><!-- documented in the "inline" group --><!-- documented in the "inline" group -->
-<p id="attr-document-href">When <code>type</code> is <code>file</code>; the <a href="#attr-document-href"><code>href</code></a> attribute is a URI pointing to the file you want the contents of.</p><p>When <code>type</code> is <code>directory</code>; the <a href="#attr-document-href"><code>href</code></a> attribute is a URI pointing to the directory you want listed.</p>
+                                xprocspec document.</p><!-- documented in the "inline" group --><!-- documented in the "inline" group --><!-- documented in the "inline" group -->
+<p id="attr-document-href">When <code>type</code> is <code>file</code>; the <a href="#attr-document-href"><code>href</code></a> attribute is a URI pointing to the file you want the contents of.</p><p>When <code>type</code> is <code>directory</code>; the <a href="#attr-document-href"><code>href</code></a> attribute is a URI pointing to the directory you want listed.</p><p>When <code>type</code> is <code>zip</code>;
+                        the <a href="#attr-document-href"><code>href</code></a> attribute is a URI pointing to the ZIP file you want
+                        listed.</p>
 <p id="attr-document-method">By default, files loaded by using <code>method="file"</code> will be loaded as XML files. Non-XML files can be loaded by
                                 specifying another <code>method</code>.</p>
+<p id="attr-document-ordered">When <code>ordered</code> is
+                            <code>true</code>, the ZIP entries are listed in lexicographical
+                            order.</p>
 <p id="attr-document-port">
                             The <code>port</code> is the name of a XProc input or output port.
                             The <code>x:document</code> element will represent the sequence of documents provided on the input port, or the sequence of documents returned on the output port.
@@ -392,6 +397,13 @@
                             If the <a href="#attr-document-type"><code>type</code></a> attribute is <a href="#the-directory-element"><code>directory</code></a>, then the <a href="#the-document-element"><code>document</code></a> element will be replaced with a directory listing of the directory pointed to by the <a href="#attr-document-href"><code>href</code></a> attribute. The <code>href</code> URI is
                             by default resolved against the base URI of the xprocspec test document. However, if you provide the <code>base-uri</code> attribute with a value of <code>temp-dir</code>, then the <code>href</code> URI will be resolved against the temporary directory
                             used for the test instead.
+                        </p><p>
+                            If the <a href="#attr-document-type"><code>type</code></a> attribute is <a href="#the-zip-element"><code>zip</code></a>, then the <a href="#the-document-element"><code>document</code></a> element will be
+                            replaced with a listing of the ZIP file pointed to by the <a href="#attr-document-href"><code>href</code></a>
+                            attribute. The <code>href</code> URI is by default resolved against the base URI of
+                            the xprocspec test document. However, if you provide the <code>base-uri</code>
+                            attribute with a value of <code>temp-dir</code>, then the <code>href</code> URI will be
+                            resolved against the temporary directory used for the test instead.
                         </p><p>
                             If the <a href="#attr-document-type"><code>type</code></a> attribute is <code>errors</code>, then a <code>c:errors</code> document (as defined in the XProc spec) will be made available if any errors occur during step execution.
                             If no errors occur, an empty sequence is returned.

--- a/www/documentation/index.html
+++ b/www/documentation/index.html
@@ -1199,6 +1199,12 @@
                         <small title="optional">?</small>
                     </dd>
                     <dd>
+                        <a href="#attr-document-ordered">
+                            <code>ordered</code>
+                        </a>
+                        <small title="optional">?</small>
+                    </dd>
+                    <dd>
                         <a href="#attr-document-port">
                             <code>port</code>
                         </a>
@@ -1249,9 +1255,14 @@
                 <p>When <code>type</code> is <code>directory</code>; the <a
                         href="#attr-document-href"><code>href</code></a> attribute is a URI pointing
                     to the directory you want listed.</p>
+                <p>When <code>type</code> is <code>zip</code>; the <a
+                        href="#attr-document-href"><code>href</code></a> attribute is a URI pointing
+                        to the ZIP file you want listed.</p>
                 <p id="attr-document-method">By default, files loaded by using
                         <code>method="file"</code> will be loaded as XML files. Non-XML files can be
                     loaded by specifying another <code>method</code>.</p>
+                <p id="attr-document-ordered">When <code>ordered</code> is
+                        <code>true</code>, the ZIP entries are listed in lexicographical order.</p>
                 <p id="attr-document-port"> The <code>port</code> is the name of a XProc input or
                     output port. The <code>x:document</code> element will represent the sequence of
                     documents provided on the input port, or the sequence of documents returned on
@@ -1305,6 +1316,16 @@
                     xprocspec test document. However, if you provide the <code>base-uri</code>
                     attribute with a value of <code>temp-dir</code>, then the <code>href</code> URI
                     will be resolved against the temporary directory used for the test instead. </p>
+                <p>
+                    If the <a href="#attr-document-type"><code>type</code></a> attribute is
+                    <a href="#the-zip-element"><code>zip</code></a>, then the
+                    <a href="#the-document-element"><code>document</code></a> element will be
+                    replaced with a listing of the ZIP file pointed to by the
+                    <a href="#attr-document-href"><code>href</code></a>
+                    attribute. The <code>href</code> URI is by default resolved against the base URI of
+                    the xprocspec test document. However, if you provide the <code>base-uri</code>
+                    attribute with a value of <code>temp-dir</code>, then the <code>href</code> URI will be
+                    resolved against the temporary directory used for the test instead.</p>
                 <p> If the <a href="#attr-document-type"><code>type</code></a> attribute is
                         <code>errors</code>, then a <code>c:errors</code> document (as defined in
                     the XProc spec) will be made available if any errors occur during step


### PR DESCRIPTION
- closes #60 (Support progress indication)
- closes #63 ("ordered" argument on x:document type='zip')