### PR TITLE
v1.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ language: java
 
 # configure the Maven environment
 before_install:
-  - source <(curl -fsSL https://raw.github.com/daisy/maven-parents/travis/before_install)
+  - source <(curl -fsSL https://raw.github.com/daisy/maven-parents/travis-2/before_install)
 
 # main task, run the verify goal
 script: mvn verify
 
 # if the build succeeds, deploy the artifact (tests are skipped)
 after_success: 
-  - source <(curl -fsSL https://raw.github.com/daisy/maven-parents/travis/after_success)
+  - source <(curl -fsSL https://raw.github.com/daisy/maven-parents/travis-2/after_success)
 
 # whitelist; only deploy master branch
 branches:
   only:
   - master
+  - /^super\/.+$/
 
 env:
   global:

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
           <h2>A tool for testing XProc scripts</h2>
         </header>
         <section class="buttons clearfix">
-          <a href="https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.0/xprocspec-1.3.0.jar" id="button-left" class="button">
-            <span>Download v1.3.0</span>
+          <a href="https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar" id="button-left" class="button">
+            <span>Download v1.3.1</span>
           </a>
           <a href="www/documentation/index.html" id="button-middle" class="button">
             <span>Documentation</span>
@@ -115,9 +115,9 @@
 
 <p><strong>Note: XML Calabash 1.1.16 or newer is required.</strong></p>
 
-<pre><code class="bash"># download and unzip xprocspec v1.3.0
-wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.0/xprocspec-1.3.0.jar
-unzip xprocspec-1.3.0.jar -d xprocspec
+<pre><code class="bash"># download and unzip xprocspec v1.3.1
+wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar
+unzip xprocspec-1.3.1.jar -d xprocspec
 
 # run the xprocspec test (change calabash path if necessary)
 java -jar ~/xmlcalabash-1.1.16-97/xmlcalabash-1.1.16-97.jar \
@@ -141,9 +141,9 @@ java -jar ~/xmlcalabash-1.1.16-97/xmlcalabash-1.1.16-97.jar \
 unzip MorganaXProc-1-0-8.zip -d morgana
 </code></pre>
 
-<pre><code class="bash"># download and unzip xprocspec v1.3.0
-wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.0/xprocspec-1.3.0.jar
-unzip xprocspec-1.3.0.jar -d xprocspec
+<pre><code class="bash"># download and unzip xprocspec v1.3.1
+wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar
+unzip xprocspec-1.3.1.jar -d xprocspec
 </code></pre>
 
 <h4>Morgana XProc CLI</h4>
@@ -179,9 +179,9 @@ TODO:
 ~/expath/pkg/bin/xrepo create repo
 export EXPATH_REPO=`pwd`/repo
 
-# download and install xprocspec v1.3.0
-wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.0/xprocspec-1.3.0.jar
-~/expath/pkg/bin/xrepo install xprocspec-1.3.0.jar
+# download and install xprocspec v1.3.1
+wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar
+~/expath/pkg/bin/xrepo install xprocspec-1.3.1.jar
 
 # optionally, observe that xprocspec is installed
 ~/expath/pkg/bin/xrepo list
@@ -240,7 +240,7 @@ to run xprocspec as part of the Maven test phase.</p>
                 &lt;dependency&gt;
                   &lt;groupId&gt;org.daisy.xprocspec&lt;/groupId&gt;
                   &lt;artifactId&gt;xprocspec&lt;/artifactId&gt;
-                  &lt;version&gt;1.3.0&lt;/version&gt;
+                  &lt;version&gt;1.3.1&lt;/version&gt;
                 &lt;/dependency&gt;
                 &lt;dependency&gt;
                   &lt;groupId&gt;org.daisy.maven&lt;/groupId&gt;

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>v1.3.1</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                 <dependency>
                   <groupId>org.daisy.maven</groupId>
                   <artifactId>xproc-engine-calabash</artifactId>
-                  <version>1.1.0</version>
+                  <version>1.1.2-SNAPSHOT</version>
                 </dependency>
                 <dependency>
                   <groupId>nu.validator.htmlparser</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.1</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.3.1</tag>
     </scm>
     
     <properties>

--- a/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
+++ b/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
@@ -19,6 +19,7 @@
         <!-- for each scenario -->
 
         <p:variable name="base" select="base-uri(/*)"/>
+        <p:variable name="label" select="/x:description/x:scenario/@label"/>
 
         <p:choose>
             <p:when test="/*[self::c:errors]">
@@ -45,7 +46,7 @@
                 <p:variable name="skip-scenario" select="if (/x:description/x:scenario[@pending]) then 'true' else 'false'"/>
 
                 <pxi:message message=" * evaluating scenario '$1' ($2)">
-                    <p:with-option name="param1" select="/x:description/x:scenario/@label"/>
+                    <p:with-option name="param1" select="$label"/>
                     <p:with-option name="param2" select="$base"/>
                     <p:with-option name="logfile" select="$logfile">
                         <p:empty/>
@@ -636,6 +637,9 @@ Error message: "{/*/text()/normalize-space()}"
                         <p:add-attribute match="/*" attribute-name="test-base-uri">
                             <p:with-option name="attribute-value" select="$base"/>
                         </p:add-attribute>
+                        <p:add-attribute match="/*" attribute-name="scenario-label">
+                            <p:with-option name="attribute-value" select="$label"/>
+                        </p:add-attribute>
                         <p:add-attribute match="/*" attribute-name="error-location" attribute-value="evaluate.xpl - evaluation of assertions"/>
 
                         <p:identity name="errors-without-was"/>
@@ -691,6 +695,9 @@ Error message: "{/*/text()/normalize-space()}"
                     </p:add-attribute>
                     <p:add-attribute match="/*" attribute-name="test-base-uri">
                         <p:with-option name="attribute-value" select="$base"/>
+                    </p:add-attribute>
+                    <p:add-attribute match="/*" attribute-name="scenario-label">
+                        <p:with-option name="attribute-value" select="$label"/>
                     </p:add-attribute>
                     <p:add-attribute match="/*" attribute-name="error-location" attribute-value="evaluate.xpl - validation of output grammar"/>
 

--- a/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
+++ b/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
@@ -736,6 +736,13 @@
                             <p:input port="stylesheet">
                                 <p:document href="infer-scenarios.xsl"/>
                             </p:input>
+                            <!--
+                                This was added to fix an issue where some documents in the output of
+                                pxi:test-preprocess would have a wrong base uri in certain
+                                cases. I'm unsure whether this is a bug in the XSLT, in other
+                                XProcSpec code, in Saxon or in Calabash.
+                            -->
+                            <p:with-option name="output-base-uri" select="base-uri(/*)"/>
                         </p:xslt>
                         <p:for-each>
                             <p:iteration-source select="/*/*"/>

--- a/src/main/resources/content/xml/xproc/report/report-to-junit.xsl
+++ b/src/main/resources/content/xml/xproc/report/report-to-junit.xsl
@@ -30,13 +30,20 @@
         <xsl:variable name="total" select="count($tests | $pending-description) + $error-count"/>
 
         <testsuite timestamp="{x:now()}" hostname="localhost" tests="{$total}" errors="{$error-count}" failures="{$failed}" skipped="{$pending}" id="{generate-id()}"
-            temp-global-duration="{x:duration($start-time,$end-time)}" temp-global-name="{x:camelCase(replace(replace(@test-base-uri,'\.xprocspec$','','i'),'^.*/([^/]*)$','$1'))}">
+            temp-global-duration="{x:duration($start-time,$end-time)}" temp-global-name="{replace(replace(@test-base-uri,'\.xprocspec$','','i'),'^.*/([^/]*)$','$1')}">
             <!-- the @disabled attribute is not used (don't know what it means as opposed to @skipped...) -->
 
             <xsl:choose>
                 <xsl:when test="$errors">
-                    <xsl:attribute name="name" select="'compilationError'"/>
-                    <xsl:attribute name="package" select="'org.daisy.xprocspec'"/>
+                    <xsl:choose>
+                        <xsl:when test="$errors/@scenario-label">
+                            <xsl:attribute name="name" select="$errors/@scenario-label"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:attribute name="name" select="'compilationError'"/>
+                            <xsl:attribute name="package" select="'org.daisy.xprocspec'"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
 
                     <properties>
                         <xsl:for-each select="@*">
@@ -69,13 +76,13 @@
                 <xsl:otherwise>
                     <xsl:choose>
                         <xsl:when test="$pending-description">
-                            <xsl:attribute name="name" select="x:camelCase($pending-description/x:scenario/@label)"/>
+                            <xsl:attribute name="name" select="$pending-description/x:scenario/@label"/>
                             <xsl:if test="$pending-description/x:scenario[@start-time and @end-time]">
                                 <xsl:attribute name="time" select="x:duration($pending-description/x:scenario/@start-time,$pending-description/x:scenario/@end-time)"/>
                             </xsl:if>
                         </xsl:when>
                         <xsl:otherwise>
-                            <xsl:attribute name="name" select="x:camelCase($scenario/@label)"/>
+                            <xsl:attribute name="name" select="$scenario/@label"/>
                             <xsl:attribute name="package" select="replace($declaration/@x:type,'^\{(.*)\}.*','$1')"/>
                             <xsl:if test="$scenario[@start-time and @end-time]">
                                 <xsl:attribute name="time" select="x:duration($scenario/@start-time,$scenario/@end-time)"/>
@@ -135,7 +142,7 @@
 </xsl:text>
 
                     <xsl:if test="$pending-description">
-                        <testcase name="pendingScenario-{x:camelCase($pending-description/x:scenario/@label)}" classname="pendingScenario" assertions="1" time="0">
+                        <testcase name="pendingScenario-{$pending-description/x:scenario/@label}" classname="pendingScenario" assertions="1" time="0">
                             <skipped type="xprocspec.skip" message="{string($pending-description/x:scenario/@pending)}">
                                 <xsl:value-of select="string($pending-description/x:scenario/@pending)"/>
                             </skipped>
@@ -146,7 +153,7 @@
                     </xsl:if>
 
                     <xsl:for-each select="$tests">
-                        <testcase name="{x:camelCase(@label)}" classname="{tokenize($declaration/@type,':')[last()]}" assertions="1" time="0">
+                        <testcase name="{@label}" classname="{tokenize($declaration/@type,':')[last()]}" assertions="1" time="0">
                             <!--
                                  TODO: @time: Time taken (in seconds) to execute the test
                              -->


### PR DESCRIPTION
- Change surefire report so that we can generate better textual output
- Travis: enable `super/*` branches
- Test with Calabash 1.1.20
- `xml:base` attributes in xprocspec tests were causing errors (closes #68)