### PR TITLE
Two changes related to Saxon update

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
           <h2>A tool for testing XProc scripts</h2>
         </header>
         <section class="buttons clearfix">
-          <a href="https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar" id="button-left" class="button">
-            <span>Download v1.3.1</span>
+          <a href="https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.2/xprocspec-1.3.2.jar" id="button-left" class="button">
+            <span>Download v1.3.2</span>
           </a>
           <a href="www/documentation/index.html" id="button-middle" class="button">
             <span>Documentation</span>
@@ -115,9 +115,9 @@
 
 <p><strong>Note: XML Calabash 1.1.16 or newer is required.</strong></p>
 
-<pre><code class="bash"># download and unzip xprocspec v1.3.1
-wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar
-unzip xprocspec-1.3.1.jar -d xprocspec
+<pre><code class="bash"># download and unzip xprocspec v1.3.2
+wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.2/xprocspec-1.3.2.jar
+unzip xprocspec-1.3.2.jar -d xprocspec
 
 # run the xprocspec test (change calabash path if necessary)
 java -jar ~/xmlcalabash-1.1.16-97/xmlcalabash-1.1.16-97.jar \
@@ -141,9 +141,9 @@ java -jar ~/xmlcalabash-1.1.16-97/xmlcalabash-1.1.16-97.jar \
 unzip MorganaXProc-1-0-8.zip -d morgana
 </code></pre>
 
-<pre><code class="bash"># download and unzip xprocspec v1.3.1
-wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar
-unzip xprocspec-1.3.1.jar -d xprocspec
+<pre><code class="bash"># download and unzip xprocspec v1.3.2
+wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.2/xprocspec-1.3.2.jar
+unzip xprocspec-1.3.2.jar -d xprocspec
 </code></pre>
 
 <h4>Morgana XProc CLI</h4>
@@ -179,9 +179,9 @@ TODO:
 ~/expath/pkg/bin/xrepo create repo
 export EXPATH_REPO=`pwd`/repo
 
-# download and install xprocspec v1.3.1
-wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.1/xprocspec-1.3.1.jar
-~/expath/pkg/bin/xrepo install xprocspec-1.3.1.jar
+# download and install xprocspec v1.3.2
+wget https://oss.sonatype.org/content/repositories/releases/org/daisy/xprocspec/xprocspec/1.3.2/xprocspec-1.3.2.jar
+~/expath/pkg/bin/xrepo install xprocspec-1.3.2.jar
 
 # optionally, observe that xprocspec is installed
 ~/expath/pkg/bin/xrepo list
@@ -240,7 +240,7 @@ to run xprocspec as part of the Maven test phase.</p>
                 &lt;dependency&gt;
                   &lt;groupId&gt;org.daisy.xprocspec&lt;/groupId&gt;
                   &lt;artifactId&gt;xprocspec&lt;/artifactId&gt;
-                  &lt;version&gt;1.3.1&lt;/version&gt;
+                  &lt;version&gt;1.3.2&lt;/version&gt;
                 &lt;/dependency&gt;
                 &lt;dependency&gt;
                   &lt;groupId&gt;org.daisy.maven&lt;/groupId&gt;

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>v1.3.2</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.3.2</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.3.2</tag>
     </scm>
     
     <properties>

--- a/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
+++ b/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
@@ -485,6 +485,14 @@ Error message: "{/*/text()/normalize-space()}"
                                             <p:input port="stylesheet">
                                                 <p:document href="expect-to-custom-invocation.xsl"/>
                                             </p:input>
+                                            <!--
+                                                This was added because in some cases the input has an empty
+                                                base URI, so that the output pipeline also gets an empty base
+                                                URI, which causes an error in the Calabash implementation of
+                                                p:split-sequence. The exact value of the base URI is not
+                                                important.
+                                            -->
+                                            <p:with-option name="output-base-uri" select="'file:/irrelevant'"/>
                                         </p:xslt>
 
                                         <!-- multiplex context and expect document sequences for cx:eval -->

--- a/src/main/resources/content/xml/xproc/utils/document-to-select-xslt.xsl
+++ b/src/main/resources/content/xml/xproc/utils/document-to-select-xslt.xsl
@@ -15,6 +15,10 @@
 
             <xsl:copy-of select="//namespace::*"/>
 
+            <xsl:element name="{$xsl-prefix}:param" namespace="http://www.w3.org/1999/XSL/Transform">
+                <xsl:attribute name="name" select="'test-base-uri'"/>
+                <xsl:attribute name="required" select="'yes'"/>
+            </xsl:element>
             <xsl:element name="{$xsl-prefix}:output" namespace="http://www.w3.org/1999/XSL/Transform">
                 <xsl:attribute name="indent" select="'yes'"/>
             </xsl:element>

--- a/src/main/resources/content/xml/xproc/utils/document.xpl
+++ b/src/main/resources/content/xml/xproc/utils/document.xpl
@@ -336,12 +336,12 @@
                         <p:pipe port="current" step="select"/>
                     </p:iteration-source>
                     <p:xslt>
-                        <p:input port="parameters">
-                            <p:empty/>
-                        </p:input>
                         <p:input port="stylesheet">
                             <p:pipe port="result" step="select.xslt"/>
                         </p:input>
+                        <p:with-param name="test-base-uri" select="base-uri(/)">
+                            <p:pipe step="main" port="document"/>
+                        </p:with-param>
                     </p:xslt>
                     <p:add-attribute match="/*" attribute-name="type" attribute-value="inline"/>
                     <p:add-attribute match="/*" attribute-name="xml:space" attribute-value="preserve"/>


### PR DESCRIPTION
1. Another base URI related bug (see also https://github.com/daisy/xprocspec/commit/e699b5ffeefd2d5985b6c0bb468173851a43b023)
2. Make `$test-base-uri` variable available also in x:document/@select. Previously I could simply do `resolve-uri(foo)` because the base URI of the static context would be that of the test file. This is not the case anymore. The best way to solve it is to make the `$test-base-uri` explicit I think. This way it can not be misunderstood. Note that I didn't update the documentation because `$test-base-uri` was not documented at all yet.