### PR TITLE
Release v1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>v1.4.2</tag>
+        <tag>HEAD</tag>
     </scm>
     
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     
     <groupId>org.daisy.xprocspec</groupId>
     <artifactId>xprocspec</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.2</version>
     <packaging>bundle</packaging>
 
     <name>xprocspec</name>
@@ -47,7 +47,7 @@
         <url>http://github.com/daisy/xprocspec</url>
         <connection>scm:git:git@github.com:daisy/xprocspec.git</connection>
         <developerConnection>scm:git:git@github.com:daisy/xprocspec.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v1.4.2</tag>
     </scm>
     
     <properties>

--- a/src/main/resources/content/xml/xproc/compile/description-to-invocation.xsl
+++ b/src/main/resources/content/xml/xproc/compile/description-to-invocation.xsl
@@ -152,7 +152,11 @@
                                                     </p:inline>
                                                 </xsl:when>
                                                 <xsl:otherwise>
-                                                    <p:document href="{resolve-uri(@href,base-uri(.))}"/>
+                                                    <xsl:variable name="href" select="resolve-uri(@href,base-uri(.))"/>
+                                                    <xsl:variable name="href" select="if (contains($href,'!/'))
+                                                                                      then replace($href,'^file:','jar:file:')
+                                                                                      else $href"/>
+                                                    <p:document href="{$href}"/>
                                                 </xsl:otherwise>
                                             </xsl:choose>
                                         </xsl:for-each>

--- a/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
+++ b/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
@@ -1,4 +1,4 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="pxi:test-evaluate" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step"
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" type="pxi:test-evaluate" name="main" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" exclude-inline-prefixes="#all" version="1.0" xpath-version="2.0" xmlns:x="http://www.daisy.org/ns/xprocspec">
 
     <p:input port="source" sequence="true"/>
@@ -263,10 +263,10 @@
 
                                     <p:when test="/x:expect[@type='count']">
                                         <!-- the minimum amount of documents -->
-                                        <p:variable name="min" select="/*/@min"/>
+                                        <p:variable name="min" select="/*/@min" cx:as="xs:string"/>
 
                                         <!-- the maximum amount of documents -->
-                                        <p:variable name="max" select="/*/@max"/>
+                                        <p:variable name="max" select="/*/@max" cx:as="xs:string"/>
 
                                         <p:count name="count">
                                             <p:input port="source">
@@ -426,7 +426,7 @@
                                         <p:identity name="test-result.before-evaluate"/>
                                         <p:group>
                                             <p:variable name="has-code" select="if (/*[@code]) then 'true' else 'false'"/>
-                                            <p:variable name="code" select="/*/@code"/>
+                                            <p:variable name="code" select="/*/@code" cx:as="xs:string"/>
                                             <p:variable name="has-message" select="if (/*[@message]) then 'true' else 'false'"/>
                                             <p:variable name="message" select="/*/@message"/>
                                             <p:in-scope-names name="vars"/>
@@ -587,7 +587,7 @@ Error message: "{/*/text()/normalize-space()}"
                             <!-- invert result on x:scenario/@xfail -->
                             <p:wrap-sequence wrapper="x:wrapper"/>
                             <p:group>
-                                <p:variable name="has-xfail" select="boolean(/*[@xfail])">
+                                <p:variable name="has-xfail" select="boolean(/*[@xfail])" cx:as="xs:string">
                                     <p:pipe port="result" step="scenario"/>
                                 </p:variable>
                                 <p:variable name="xfail-text" select="/*/@xfail/normalize-space()">

--- a/src/main/resources/content/xml/xproc/utils/assert.xpl
+++ b/src/main/resources/content/xml/xproc/utils/assert.xpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step type="pxi:assert" name="main" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc"
+<p:declare-step type="pxi:assert" name="main" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" exclude-inline-prefixes="#all" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -19,22 +19,22 @@
         <p:pipe port="result" step="result"/>
     </p:output>
     
-    <p:option name="test" select="''"/>                                             <!-- boolean -->
+    <p:option name="test" select="''" cx:as="xs:string"/>                           <!-- boolean -->
     <p:option name="test-count-min" select="''"/>                                   <!-- positive integer -->
     <p:option name="test-count-max" select="''"/>                                   <!-- positive integer -->
     <p:option name="error-code" select="''"/>                                       <!-- QName - if not given, only a warning will be displayed. -->
     <p:option name="error-code-prefix" select="''"/>                                <!-- NCName -->
     <p:option name="error-code-namespace" select="''"/>                             <!-- anyURI -->
-    <p:option name="message" required="true"/>                                      <!-- description of what you are asserting. $1, $2 etc will be replaced with the contents of param1, param2 etc. -->
-    <p:option name="param1" select="''"/>
-    <p:option name="param2" select="''"/>
-    <p:option name="param3" select="''"/>
-    <p:option name="param4" select="''"/>
-    <p:option name="param5" select="''"/>
-    <p:option name="param6" select="''"/>
-    <p:option name="param7" select="''"/>
-    <p:option name="param8" select="''"/>
-    <p:option name="param9" select="''"/>
+    <p:option name="message" required="true" cx:as="xs:string"/>                    <!-- description of what you are asserting. $1, $2 etc will be replaced with the contents of param1, param2 etc. -->
+    <p:option name="param1" select="''" cx:as="xs:string"/>
+    <p:option name="param2" select="''" cx:as="xs:string"/>
+    <p:option name="param3" select="''" cx:as="xs:string"/>
+    <p:option name="param4" select="''" cx:as="xs:string"/>
+    <p:option name="param5" select="''" cx:as="xs:string"/>
+    <p:option name="param6" select="''" cx:as="xs:string"/>
+    <p:option name="param7" select="''" cx:as="xs:string"/>
+    <p:option name="param8" select="''" cx:as="xs:string"/>
+    <p:option name="param9" select="''" cx:as="xs:string"/>
     <!-- in the unlikely event that you need more parameters you'll have to format the message string yourself -->
     <p:option name="logfile" select="''"/>
     

--- a/src/main/resources/content/xml/xproc/utils/error.xpl
+++ b/src/main/resources/content/xml/xproc/utils/error.xpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step type="pxi:error" name="main" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:x="http://www.emc.com/documentum/xml/xproc"
+<p:declare-step type="pxi:error" name="main" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:x="http://www.emc.com/documentum/xml/xproc" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" exclude-inline-prefixes="#all" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -23,23 +23,23 @@
         <p:pipe port="result" step="error"/>
     </p:output>
 
-    <p:option name="code" required="true"/>
+    <p:option name="code" required="true" cx:as="xs:string"/>
     <!-- QName -->
     <p:option name="code-prefix" select="''"/>
     <!-- NCName -->
     <p:option name="code-namespace" select="''"/>
     <!-- anyURI -->
-    <p:option name="message" required="true"/>
+    <p:option name="message" required="true" cx:as="xs:string"/>
     <!-- description of the error that occured. $1, $2 etc will be replaced with the contents of param1, param2 etc. -->
-    <p:option name="param1" select="''"/>
-    <p:option name="param2" select="''"/>
-    <p:option name="param3" select="''"/>
-    <p:option name="param4" select="''"/>
-    <p:option name="param5" select="''"/>
-    <p:option name="param6" select="''"/>
-    <p:option name="param7" select="''"/>
-    <p:option name="param8" select="''"/>
-    <p:option name="param9" select="''"/>
+    <p:option name="param1" select="''" cx:as="xs:string"/>
+    <p:option name="param2" select="''" cx:as="xs:string"/>
+    <p:option name="param3" select="''" cx:as="xs:string"/>
+    <p:option name="param4" select="''" cx:as="xs:string"/>
+    <p:option name="param5" select="''" cx:as="xs:string"/>
+    <p:option name="param6" select="''" cx:as="xs:string"/>
+    <p:option name="param7" select="''" cx:as="xs:string"/>
+    <p:option name="param8" select="''" cx:as="xs:string"/>
+    <p:option name="param9" select="''" cx:as="xs:string"/>
     <!-- in the unlikely event that you need more parameters you'll have to format the message string yourself -->
     <p:option name="logfile" select="''"/>
     

--- a/src/main/resources/content/xml/xproc/utils/message.xpl
+++ b/src/main/resources/content/xml/xproc/utils/message.xpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step type="pxi:message" name="main" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:x="http://www.emc.com/documentum/xml/xproc"
+<p:declare-step type="pxi:message" name="main" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:x="http://www.emc.com/documentum/xml/xproc" xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" xmlns:px="http://www.daisy.org/ns/xprocspec" exclude-inline-prefixes="#all" version="1.0">
 
     <p:documentation xmlns="http://www.w3.org/1999/xhtml">
@@ -22,17 +22,17 @@
 
     <p:option name="severity" select="'INFO'"/>
     <!-- one of either: WARN, INFO, DEBUG. Defaults to "INFO". Use px:error to throw errors. -->
-    <p:option name="message" required="true"/>
+    <p:option name="message" required="true" cx:as="xs:string"/>
     <!-- message to be logged. $1, $2 etc will be replaced with the contents of param1, param2 etc. -->
-    <p:option name="param1" select="''"/>
-    <p:option name="param2" select="''"/>
-    <p:option name="param3" select="''"/>
-    <p:option name="param4" select="''"/>
-    <p:option name="param5" select="''"/>
-    <p:option name="param6" select="''"/>
-    <p:option name="param7" select="''"/>
-    <p:option name="param8" select="''"/>
-    <p:option name="param9" select="''"/>
+    <p:option name="param1" select="''" cx:as="xs:string"/>
+    <p:option name="param2" select="''" cx:as="xs:string"/>
+    <p:option name="param3" select="''" cx:as="xs:string"/>
+    <p:option name="param4" select="''" cx:as="xs:string"/>
+    <p:option name="param5" select="''" cx:as="xs:string"/>
+    <p:option name="param6" select="''" cx:as="xs:string"/>
+    <p:option name="param7" select="''" cx:as="xs:string"/>
+    <p:option name="param8" select="''" cx:as="xs:string"/>
+    <p:option name="param9" select="''" cx:as="xs:string"/>
     <!-- in the unlikely event that you need more parameters you'll have to format the message string yourself -->
     <p:option name="logfile" select="''"/>
 

--- a/src/main/resources/content/xml/xproc/utils/recursive-directory-list.xpl
+++ b/src/main/resources/content/xml/xproc/utils/recursive-directory-list.xpl
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:declare-step version="1.0" type="pxi:directory-list" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/">
+<p:declare-step version="1.0" type="pxi:directory-list" xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:p="http://www.w3.org/ns/xproc" xmlns:pxi="http://www.daisy.org/ns/xprocspec/xproc-internal/" xmlns:cx="http://xmlcalabash.com/ns/extensions" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
     <p:documentation>The p:directory-list step will return the contents of a single directory. The px:directory-list step will process a directory and it's subdirectories recursively. See also:
         http://xproc.org/library/#recursive-directory-list.</p:documentation>
 
     <p:output port="result"/>
     <p:option name="path" required="true"/>
-    <p:option name="depth" select="-1"/>
+    <p:option name="depth" select="'-1'"/>
 
     <p:declare-step type="pxi:directory-list-recursive">
         <p:output port="result"/>
         <p:option name="path" required="true"/>
-        <p:option name="depth" select="-1"/>
+        <p:option name="depth" cx:as="xs:string" select="'-1'"/>
 
         <p:directory-list>
             <p:with-option name="path" select="$path"/>
@@ -21,10 +21,10 @@
             <p:variable name="name" select="/*/@name"/>
 
             <p:choose>
-                <p:when test="$depth != 0">
+                <p:when test="$depth != '0'">
                     <pxi:directory-list-recursive>
                         <p:with-option name="path" select="concat($path,'/',$name)"/>
-                        <p:with-option name="depth" select="$depth - 1"/>
+                        <p:with-option name="depth" select="number($depth) - 1"/>
                     </pxi:directory-list-recursive>
                 </p:when>
                 <p:otherwise>


### PR DESCRIPTION
- Support loading input documents from ZIP (previously only supported within `context` and `expect`)
- Make compatible with "[general-values](https://xmlcalabash.com/docs/reference/langext.html)"-enabled XMLCalabash