### PR TITLE
Feature/52 support of three dots

### DIFF
--- a/src/main/resources/content/xml/xproc/evaluate/compare.xpl
+++ b/src/main/resources/content/xml/xproc/evaluate/compare.xpl
@@ -40,12 +40,24 @@
         </p:otherwise>
     </p:choose>
     <p:identity name="alternate"/>
+    
+    <p:xslt name="ignores">
+        <p:input port="source">
+            <p:pipe port="result" step="source"/>
+            <p:pipe port="result" step="alternate"/>
+        </p:input>
+        <p:input port="stylesheet">
+            <p:document href="ignore.xsl"/>
+        </p:input>
+        <p:input port="parameters">
+            <p:empty/>
+        </p:input>
+    </p:xslt>
+    
+    
 
     <p:compare name="compare">
         <p:with-option name="fail-if-not-equal" select="$fail-if-not-equal"/>
-        <p:input port="source">
-            <p:pipe port="result" step="source"/>
-        </p:input>
         <p:input port="alternate">
             <p:pipe port="result" step="alternate"/>
         </p:input>

--- a/src/main/resources/content/xml/xproc/evaluate/ignore.xsl
+++ b/src/main/resources/content/xml/xproc/evaluate/ignore.xsl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:x="http://www.daisy.org/ns/xprocspec"
+    exclude-result-prefixes="#all"
+    version="2.0">
+    <xsl:variable name="alternate" select="collection()[2]"/>
+    <xsl:variable name="ignore-nodes" select="x:ignore-node-paths($alternate)"/>
+
+    <xsl:key name="node-path" match="@* | node()" use="x:path(.)"/>
+    
+    <xsl:template match="node() | @*">
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="key('node-path', $ignore-nodes)">
+        <xsl:choose>
+            <xsl:when test="self::text()">
+                <xsl:text>...</xsl:text>
+            </xsl:when>
+            <xsl:when test="self::element()">
+                <xsl:copy>
+                    <xsl:apply-templates select="@*"/>
+                    <xsl:text>...</xsl:text>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:when test="self::attribute()">
+                <xsl:attribute name="{name()}" select="'...'" namespace="{namespace-uri()}"/>
+            </xsl:when>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:function name="x:ignore-node-paths" as="xs:string*">
+        <xsl:param name="alternate" as="document-node()"/>
+        <xsl:variable name="ignore-text" select="$alternate//text()[. = '...']"/>
+        <xsl:variable name="ignore-text" select="$ignore-text / x:path(parent::*)"/>
+        <xsl:variable name="ignore-attr" select="$alternate//@*[. = '...']/x:path(.)"/>
+        
+        <xsl:sequence select="$ignore-text, $ignore-attr"/>
+        
+    </xsl:function>
+    
+    <xsl:function name="x:path" as="xs:string">
+        <xsl:param name="node" as="node()"/>
+        <xsl:variable name="parent-path" select="
+            if ($node instance of document-node()) then '' else x:path($node/parent::node())
+            "/>
+        <xsl:variable name="node-name" select="x:node-name($node)"/>
+        <xsl:variable name="node-position" select="
+            count($node/preceding-sibling::node()[x:node-name(.) = $node-name]) + 1
+            "/>
+        <xsl:variable name="predicate" select="
+            if ($node instance of attribute()) then '' else concat('[', $node-position, ']')
+            "/>
+        
+        <xsl:sequence select="concat($parent-path, '/', $node-name, $predicate)"/>
+    </xsl:function>
+    
+    <xsl:function name="x:node-name" as="xs:string">
+        <xsl:param name="node" as="node()"/>
+        
+        <xsl:variable name="namespace" select="$node/namespace-uri()"/>
+        <xsl:variable name="name" select="concat('Q{', $namespace, '}', local-name($node))"/>
+        
+        <xsl:sequence select="
+                 if ($node instance of text()) 
+               then 'text()' 
+            else if ($node instance of comment()) 
+               then 'comment()' 
+            else if ($node instance of processing-instruction()) 
+               then 'processing-instruction()' 
+            else if ($node instance of document-node()) 
+               then '' 
+            else if ($node instance of element()) 
+               then $name 
+            else if ($node instance of attribute() and $namespace = '') 
+               then local-name($node) 
+            else if ($node instance of attribute()) 
+               then $name 
+               else ''
+            "/>
+        
+    </xsl:function>
+    
+</xsl:stylesheet>

--- a/src/test/xprocspec/tests/ignore-1.xprocspec
+++ b/src/test/xprocspec/tests/ignore-1.xprocspec
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.daisy.org/ns/xprocspec/xprocspec.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<x:description xmlns:c="http://www.w3.org/ns/xproc-step" xmlns:x="http://www.daisy.org/ns/xprocspec" xmlns:e="http://example.net/ns" script="../steps/identity.xpl">
+
+    <x:scenario label="running xprocspec test which refers to a non-existing port">
+        <x:call step="e:identity">
+            <x:option name="option.required" select="''"/>
+            <x:input port="source.document.primary">
+                <x:document type="inline">
+                    <doc1 attr="value">
+                        <child>text-content</child>
+                        <child>mix<e>ed</e>content</child>
+                    </doc1>
+                </x:document>
+            </x:input>
+        </x:call>
+
+        <x:context label="the primary input port">
+            <x:document type="port" port="source.document.primary"/>
+        </x:context>
+        <x:expect type="compare" label="Should be equal to input document ignoring ...">
+            <x:document type="inline">
+                <doc1 attr="value">
+                    <child>...</child>
+                    <child>mix<e>ed</e>content</child>
+                </doc1>
+            </x:document>
+        </x:expect>
+        <x:expect type="compare" label="Should be equal to input document ignoring mixed content with ...">
+            <x:document type="inline">
+                <doc1 attr="value">
+                    <child>text-content</child>
+                    <child>...</child>
+                </doc1>
+            </x:document>
+        </x:expect>
+        <x:expect type="compare" label="Should be equal to input document ignoring attributes with ...">
+            <x:document type="inline">
+                <doc1 attr="...">
+                    <child>text-content</child>
+                    <child>mix<e>ed</e>content</child>
+                </doc1>
+            </x:document>
+        </x:expect>
+    </x:scenario>
+
+</x:description>


### PR DESCRIPTION
Hi,

as I needed the three dot ignore logic (issue #52) for some of my projects, I made a small implementation for it using just a cleaning XSLT inbetween.

It works the same as in XSpec for most cases. The only known cases are three dots in mixed content like `<foo>...<bar/></foo>`. This is not supported by my implementation, and I don't see an easy way to do it with my approach. But actually, I have never used the mixed-content dots in XSpec, so I am not sure how important it is for others.

So, if you don't have any other plans with this issue, I would be happy if you could include this in the next release!

Best regards,
Nico

