### PR TITLE
Bugfix: there can be at most one step declaration under test

### DIFF
--- a/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
+++ b/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
@@ -620,6 +620,7 @@
                                     </p:iteration-source>
                                     <p:delete match="//@exclude-inline-prefixes"/>
                                 </p:for-each>
+                                <p:split-sequence test="position()=1"/>
                                 <p:identity name="step-declaration"/>
                                 <p:count/>
                                 <p:choose>


### PR DESCRIPTION
I added a `<p:split-sequence test="position()=1"/>` before a step (`p:delete`) that expects only a single document but received multiple.

In my XProcSpec test that resulted in this error, the step under test was found more than once (via multiple import paths). Strangely enough this situation had never happened before.