### PR TITLE
Set output-base-uri on p:xslt whenever needed

### DIFF
--- a/src/main/resources/content/xml/xproc/compile/compile.xpl
+++ b/src/main/resources/content/xml/xproc/compile/compile.xpl
@@ -78,6 +78,7 @@
                             <p:input port="stylesheet">
                                 <p:document href="description-to-invocation.xsl"/>
                             </p:input>
+                            <p:with-option name="output-base-uri" select="base-uri(/)"/>
                         </p:xslt>
                         <pxi:message message="   * done">
                             <p:with-option name="logfile" select="$logfile">

--- a/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
+++ b/src/main/resources/content/xml/xproc/evaluate/evaluate.xpl
@@ -208,6 +208,7 @@
                                                 <p:input port="stylesheet">
                                                     <p:pipe port="result" step="xpath-xslt"/>
                                                 </p:input>
+                                                <p:with-option name="output-base-uri" select="base-uri(/)"/>
                                             </p:xslt>
                                         </p:for-each>
 
@@ -485,14 +486,7 @@ Error message: "{/*/text()/normalize-space()}"
                                             <p:input port="stylesheet">
                                                 <p:document href="expect-to-custom-invocation.xsl"/>
                                             </p:input>
-                                            <!--
-                                                This was added because in some cases the input has an empty
-                                                base URI, so that the output pipeline also gets an empty base
-                                                URI, which causes an error in the Calabash implementation of
-                                                p:split-sequence. The exact value of the base URI is not
-                                                important.
-                                            -->
-                                            <p:with-option name="output-base-uri" select="'file:/irrelevant'"/>
+                                            <p:with-option name="output-base-uri" select="base-uri(/)"/>
                                         </p:xslt>
 
                                         <!-- multiplex context and expect document sequences for cx:eval -->

--- a/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
+++ b/src/main/resources/content/xml/xproc/preprocess/preprocess.xpl
@@ -386,6 +386,7 @@
                                     <p:input port="stylesheet">
                                         <p:document href="xprocTestSuite-to-xprocspec.xsl"/>
                                     </p:input>
+                                    <p:with-option name="output-base-uri" select="base-uri(/)"/>
                                 </p:xslt>
                             </p:otherwise>
                         </p:choose>
@@ -736,13 +737,7 @@
                             <p:input port="stylesheet">
                                 <p:document href="infer-scenarios.xsl"/>
                             </p:input>
-                            <!--
-                                This was added to fix an issue where some documents in the output of
-                                pxi:test-preprocess would have a wrong base uri in certain
-                                cases. I'm unsure whether this is a bug in the XSLT, in other
-                                XProcSpec code, in Saxon or in Calabash.
-                            -->
-                            <p:with-option name="output-base-uri" select="base-uri(/*)"/>
+                            <p:with-option name="output-base-uri" select="base-uri(/)"/>
                         </p:xslt>
                         <p:for-each>
                             <p:iteration-source select="/*/*"/>

--- a/src/main/resources/content/xml/xproc/report/report.xpl
+++ b/src/main/resources/content/xml/xproc/report/report.xpl
@@ -67,6 +67,7 @@
         <p:input port="stylesheet">
             <p:document href="report-to-html.xsl"/>
         </p:input>
+        <p:with-option name="output-base-uri" select="base-uri(/)"/>
     </p:xslt>
     <p:identity name="html"/>
 
@@ -138,6 +139,7 @@
             <p:input port="stylesheet">
                 <p:document href="report-to-junit.xsl"/>
             </p:input>
+            <p:with-option name="output-base-uri" select="base-uri(/)"/>
         </p:xslt>
     </p:for-each>
     <p:wrap-sequence wrapper="testsuites"/>

--- a/src/main/resources/content/xml/xproc/utils/document.xpl
+++ b/src/main/resources/content/xml/xproc/utils/document.xpl
@@ -343,11 +343,12 @@
                         <p:with-param name="test-base-uri" select="base-uri(/)">
                             <p:pipe step="main" port="document"/>
                         </p:with-param>
+                        <p:with-option name="output-base-uri" select="resolve-uri(base-uri(/*),$unfiltered-base)"/>
                     </p:xslt>
                     <p:add-attribute match="/*" attribute-name="type" attribute-value="inline"/>
                     <p:add-attribute match="/*" attribute-name="xml:space" attribute-value="preserve"/>
                     <p:add-attribute match="/*" attribute-name="xml:base">
-                        <p:with-option name="attribute-value" select="resolve-uri(base-uri(/*),$unfiltered-base)"/>
+                        <p:with-option name="attribute-value" select="base-uri(/)"/>
                     </p:add-attribute>
                 </p:for-each>
             </p:for-each>

--- a/src/main/resources/content/xml/xproc/utils/html-load.xpl
+++ b/src/main/resources/content/xml/xproc/utils/html-load.xpl
@@ -96,5 +96,6 @@
         <p:input port="stylesheet">
             <p:document href="namespace-fixup.xsl"/>
         </p:input>
+        <p:with-option name="output-base-uri" select="base-uri(/)"/>
     </p:xslt>
 </p:declare-step>


### PR DESCRIPTION
This is a commit I had lying around and had forgotten about (until I created https://github.com/daisy/xprocspec/pull/80). I think I might have done the change when attempting to update to Saxon 10.

---

Set output-base-uri on p:xslt whenever needed to ensure the output gets the base URI of the input, because we should not rely on XMLCalabash to do this for us. The XProc specification states that in absence of the output-base-uri option, the base URI of the output document is the base URI of the first input document, but it leaves open for interpretation what should happen with the document's elements. If we use output-base-uri, we can be sure that the document's elements get the base URI we expect (this option is passed on straight to Saxon).